### PR TITLE
Implement commit protocol

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,7 @@ impl<H, N: Copy, S, Id> SignedMessage<H, N, S, Id> {
 	}
 }
 
+/// A commit message which is an aggregate of precommits.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
 pub struct Commit<H, N, S, Id> {
@@ -212,6 +213,7 @@ pub struct Commit<H, N, S, Id> {
 	pub precommits: Vec<SignedPrecommit<H, N, S, Id>>,
 }
 
+/// A signed precommit message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
 pub struct SignedPrecommit<H, N, S, Id> {
@@ -223,6 +225,7 @@ pub struct SignedPrecommit<H, N, S, Id> {
 	pub id: Id,
 }
 
+/// A commit message with compact representation of authentication data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
 pub struct CompactCommit<H, N, S, Id> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,11 @@ impl<H: Clone, N: Clone, S, Id> From<Commit<H, N, S, Id>> for CompactCommit<H, N
 	}
 }
 
+fn threshold(total_weight: u64) -> u64 {
+	let faulty = total_weight.saturating_sub(1) / 3;
+	total_weight - faulty
+}
+
 #[cfg(test)]
 mod tests {
 	#[cfg(feature = "derive-codec")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,17 +223,6 @@ pub struct SignedPrecommit<H, N, S, Id> {
 	pub id: Id,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
-pub struct SignedCommit<H, N, S, Id> {
-	/// The commit message which has been signed.
-	pub commit: Commit<H, N, S, Id>,
-	/// The signature on the message.
-	pub signature: S,
-	/// The Id of the signer.
-	pub id: Id,
-}
-
 #[cfg(test)]
 mod tests {
 	#[cfg(feature = "derive-codec")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,39 @@ impl<H, N: Copy, S, Id> SignedMessage<H, N, S, Id> {
 	}
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+pub struct Commit<H, N, S, Id> {
+	/// The target block's hash.
+	pub target_hash: H,
+	/// The target block's number
+	pub target_number: N,
+	/// Precommits for target block or any block after it that justify this commit.
+	pub justification: Vec<SignedPrecommit<H, N, S, Id>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+pub struct SignedPrecommit<H, N, S, Id> {
+	/// The precommit message which has been signed.
+	pub precommit: Precommit<H, N>,
+	/// The signature on the message.
+	pub signature: S,
+	/// The Id of the signer.
+	pub id: Id,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+pub struct SignedCommit<H, N, S, Id> {
+	/// The commit message which has been signed.
+	pub commit: Commit<H, N, S, Id>,
+	/// The signature on the message.
+	pub signature: S,
+	/// The Id of the signer.
+	pub id: Id,
+}
+
 #[cfg(test)]
 mod tests {
 	#[cfg(feature = "derive-codec")]

--- a/src/round.rs
+++ b/src/round.rs
@@ -667,6 +667,7 @@ mod tests {
 			Precommit::new("FC", 10),
 			"Alice",
 			Signature("Alice"),
+			false,
 		).unwrap();
 
 		round.import_precommit(
@@ -674,6 +675,7 @@ mod tests {
 			Precommit::new("ED", 10),
 			"Bob",
 			Signature("Bob"),
+			false,
 		).unwrap();
 
 		assert_eq!(round.finalized, None);
@@ -709,6 +711,7 @@ mod tests {
 			Precommit::new("EA", 7),
 			"Eve",
 			Signature("Eve"),
+			false,
 		).unwrap();
 
 		assert_eq!(round.finalized, Some(("EA", 7)));

--- a/src/round.rs
+++ b/src/round.rs
@@ -189,6 +189,7 @@ impl<Id: Hash + Eq + Clone, Vote: Clone + Eq, Signature: Clone + Eq> VoteTracker
 		}
 	}
 
+	// Returns all imported votes.
 	fn votes(&self) -> Vec<(Id, Vote, Signature)> {
 		let mut votes = Vec::new();
 
@@ -545,14 +546,12 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		self.graph.base()
 	}
 
-	pub fn weight(&self, signer: &Id) -> Option<u64> {
-		self.voters.get(signer).cloned()
+	/// Return the round voters weights.
+	pub fn voters(&self) -> &HashMap<Id, u64> {
+		&self.voters
 	}
 
-	pub fn is_voter(&self, id: &Id) -> bool {
-		self.voters.contains_key(id)
-	}
-
+	/// Return all imported precommits.
 	pub fn precommits(&self) -> Vec<(Id, Precommit<H, N>, Signature)> {
 		self.precommit.votes()
 	}

--- a/src/round.rs
+++ b/src/round.rs
@@ -546,7 +546,7 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		self.graph.base()
 	}
 
-	/// Return the round voters weights.
+	/// Return the round voters and weights.
 	pub fn voters(&self) -> &HashMap<Id, u64> {
 		&self.voters
 	}

--- a/src/round.rs
+++ b/src/round.rs
@@ -24,7 +24,7 @@ use std::ops::AddAssign;
 
 use bitfield::{Bitfield, Shared as BitfieldContext, LiveBitfield};
 
-use super::{Equivocation, Prevote, Precommit, Chain, BlockNumberOps};
+use super::{Equivocation, Prevote, Precommit, Chain, BlockNumberOps, threshold};
 
 #[derive(Hash, Eq, PartialEq)]
 struct Address;
@@ -555,11 +555,6 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 	pub fn precommits(&self) -> Vec<(Id, Precommit<H, N>, Signature)> {
 		self.precommit.votes()
 	}
-}
-
-fn threshold(total_weight: u64) -> u64 {
-	let faulty = total_weight.saturating_sub(1) / 3;
-	total_weight - faulty
 }
 
 #[cfg(test)]

--- a/src/round.rs
+++ b/src/round.rs
@@ -549,6 +549,10 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		self.voters.get(signer).cloned()
 	}
 
+	pub fn is_voter(&self, id: &Id) -> bool {
+		self.voters.contains_key(id)
+	}
+
 	pub fn precommits(&self) -> Vec<(Id, Precommit<H, N>, Signature)> {
 		self.precommit.votes()
 	}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -100,11 +100,13 @@ impl Chain<&'static str, u32> for DummyChain {
 		loop {
 			match self.inner.get(block) {
 				None => return Err(Error::NotDescendent),
-				Some(record) => { block = record.parent; }
+				Some(record) => {
+					if block == base { break }
+					block = record.parent;
+				}
 			}
 
 			if block == NULL_HASH { return Err(Error::NotDescendent) }
-			if block == base { break }
 
 			ancestry.push(block);
 		}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -100,13 +100,11 @@ impl Chain<&'static str, u32> for DummyChain {
 		loop {
 			match self.inner.get(block) {
 				None => return Err(Error::NotDescendent),
-				Some(record) => {
-					if block == base { break }
-					block = record.parent;
-				}
+				Some(record) => { block = record.parent; }
 			}
 
 			if block == NULL_HASH { return Err(Error::NotDescendent) }
+			if block == base { break }
 
 			ancestry.push(block);
 		}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -230,12 +230,7 @@ impl ::voter::Environment<&'static str, u32> for Environment {
 	fn finalize_block(&self, hash: &'static str, number: u32, commit: Commit<&'static str, u32, Signature, Id>) -> Result<(), Error> {
 		let mut chain = self.chain.lock();
 
-		if number as u32 <= chain.finalized.1 {
-			// ignore finalization lower than our best finalized
-			// may be triggered by the commit protocol
-			return Ok(());
-		}
-
+		if number as u32 <= chain.finalized.1 { panic!("Attempted to finalize backwards") }
 		assert!(chain.ancestry(chain.finalized.0, hash).is_ok(), "Safety violation: reverting finalized block.");
 		chain.finalized = (hash, number as _);
 		self.listeners.lock().retain(|s| s.unbounded_send((hash, number as _, commit.clone())).is_ok());

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -139,7 +139,7 @@ impl Chain<&'static str, u32> for DummyChain {
 pub struct Id(pub u32);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Signature(u32);
+pub struct Signature(pub u32);
 
 pub struct Environment {
 	chain: Mutex<DummyChain>,
@@ -217,7 +217,7 @@ impl ::voter::Environment<&'static str, u32> for Environment {
 	}
 
 	fn committer_data(&self) -> (Self::CommitIn, Self::CommitOut) {
-		let (incoming, outgoing) = self.network.commits_comms(self.local_id);
+		let (incoming, outgoing) = self.network.make_commits_comms(self.local_id);
 		(Box::new(incoming), Box::new(outgoing))
 	}
 
@@ -325,7 +325,7 @@ pub struct Network {
 }
 
 impl Network {
-	fn make_round_comms(&self, round_number: u64, node_id: Id) -> (
+	pub fn make_round_comms(&self, round_number: u64, node_id: Id) -> (
 		impl Stream<Item=SignedMessage<&'static str, u32, Signature, Id>,Error=Error>,
 		impl Sink<SinkItem=Message<&'static str, u32>,SinkError=Error>
 	) {
@@ -339,7 +339,7 @@ impl Network {
 			})
 	}
 
-	pub fn commits_comms(&self, node_id: Id) -> (
+	pub fn make_commits_comms(&self, node_id: Id) -> (
 		impl Stream<Item=(u64, SignedCommit<&'static str, u32, Signature, Id>),Error=Error>,
 		impl Sink<SinkItem=(u64, Commit<&'static str, u32, Signature, Id>),SinkError=Error>
 	) {

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -765,7 +765,7 @@ impl<H, N, E: Environment<H, N>> Future for Voter<H, N, E> where
 
 		self.env.completed(self.best_round.votes.number(), self.best_round.votes.state())?;
 
-		let old_number = self.best_round.votes.number() + 1;
+		let old_number = self.best_round.votes.number();
 		let next_number = old_number + 1;
 		let next_round_data = self.env.round_data(next_number);
 

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use round::{Round, State as RoundState};
-use ::{Chain, Equivocation, Message, Prevote, Precommit, SignedMessage, BlockNumberOps};
+use ::{Chain, Commit, Equivocation, Message, Prevote, Precommit, SignedCommit, SignedMessage, SignedPrecommit, BlockNumberOps};
 
 /// Necessary environment for a voter.
 ///
@@ -472,39 +472,6 @@ impl<H, N, E: Environment<H, N>> Future for BackgroundRound<H, N, E> where
 			Ok(Async::NotReady)
 		}
 	}
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
-pub struct Commit<H, N, S, Id> {
-	/// The target block's hash.
-	pub target_hash: H,
-	/// The target block's number
-	pub target_number: N,
-	/// Precommits for target block or any block after it that justify this commit.
-	pub justification: Vec<SignedPrecommit<H, N, S, Id>>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
-pub struct SignedPrecommit<H, N, S, Id> {
-	/// The precommit message which has been signed.
-	pub precommit: Precommit<H, N>,
-	/// The signature on the message.
-	pub signature: S,
-	/// The Id of the signer.
-	pub id: Id,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
-pub struct SignedCommit<H, N, S, Id> {
-	/// The commit message which has been signed.
-	pub commit: Commit<H, N, S, Id>,
-	/// The signature on the message.
-	pub signature: S,
-	/// The Id of the signer.
-	pub id: Id,
 }
 
 pub struct RoundCommitter<H, N, E: Environment<H, N>> where

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -575,6 +575,22 @@ impl<H, N, E: Environment<H, N>> RoundCommitter<H, N, E> where
 	}
 }
 
+/// Implements the commit protocol.
+///
+/// The commit protocol allows a node to broadcast a message that finalizes a
+/// given block and includes a set of precommits as proof.
+///
+/// - When a round is completable and we precommitted we start a commit timer
+/// and start accepting commit messages;
+/// - When we receive a commit message if it targets a block higher than what
+/// we've finalized we validate it and import its precommits if valid;
+/// - When our commit timer triggers we check if we've received any commit
+/// message for a block equal to what we've finalized, if we haven't then we
+/// broadcast a commit.
+///
+/// Additionally, we also listen to commit messages from rounds that aren't
+/// currently running, we validate the commit and dispatch a finalization
+/// notification (if any) to the environment.
 struct Committer<H, N, E: Environment<H, N>> where
 	H: Hash + Clone + Eq + Ord + ::std::fmt::Debug,
 	N: Copy + BlockNumberOps + ::std::fmt::Debug,

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -230,7 +230,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 					}
 				}
 				Message::Precommit(precommit) => {
-					if let Some(e) = self.votes.import_precommit(&*self.env, precommit, id, signature, false)? {
+					if let Some(e) = self.votes.import_precommit(&*self.env, precommit, id, signature)? {
 						self.env.precommit_equivocation(self.votes.number(), e);
 					}
 				}
@@ -529,7 +529,7 @@ impl<H, N, E: Environment<H, N>> RoundCommitter<H, N, E> where
 		}
 
 		for SignedPrecommit { precommit, signature, id } in commit.justification.clone() {
-			if let Some(e) = voting_round.votes.import_precommit(env, precommit, id, signature, true)? {
+			if let Some(e) = voting_round.votes.import_precommit(env, precommit, id, signature)? {
 				env.precommit_equivocation(voting_round.votes.number(), e);
 			}
 		}

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -573,23 +573,20 @@ impl<H, N, E: Environment<H, N>> RoundCommitter<H, N, E> where
 
 		let voting_round = self.voting_round.lock();
 		let commit = || -> Option<Commit<H, N, E::Signature, E::Id>> {
-			if let Some((target_hash, target_number)) = voting_round.votes.finalized().cloned() {
-				let justification = voting_round.votes.valid_precommits().map(|(id, precommit, signature)| {
-					SignedPrecommit {
-						precommit: precommit.clone(),
-						signature: signature.clone(),
-						id: id.clone(),
-					}
-				}).collect();
+			let (target_hash, target_number) = voting_round.votes.finalized().cloned()?;
+			let justification = voting_round.votes.valid_precommits().map(|(id, precommit, signature)| {
+				SignedPrecommit {
+					precommit: precommit.clone(),
+					signature: signature.clone(),
+					id: id.clone(),
+				}
+			}).collect();
 
-				return Some(Commit {
-					target_hash,
-					target_number,
-					justification,
-				});
-			}
-
-			None
+			Some(Commit {
+				target_hash,
+				target_number,
+				justification,
+			})
 		};
 
 		match (self.last_commit.take(), voting_round.votes.finalized()) {

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -623,6 +623,8 @@ impl<H, N, E: Environment<H, N>> Committer<H, N, E> where
 					threshold,
 					&*self.env,
 				)? {
+					// TODO: should we check if > last finalized to avoid
+					// finalizing backwards?
 					self.env.finalize_block(finalized_hash, finalized_number)?;
 				}
 			}

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -109,6 +109,16 @@ enum State<T> {
 	Precommitted,
 }
 
+impl<T> std::fmt::Debug for State<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		match self {
+			State::Start(..) => write!(f, "Start"),
+			State::Prevoted(_) => write!(f, "Prevoted"),
+			State::Precommitted => write!(f, "Precommitted"),
+		}
+    }
+}
+
 struct Buffered<S: Sink> {
 	inner: S,
 	buffer: VecDeque<S::SinkItem>,
@@ -185,7 +195,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 	// Poll the round. When the round is completable and messages have been flushed, it will return `Async::Ready` but
 	// can continue to be polled.
 	fn poll(&mut self) -> Poll<(), E::Error> {
-		trace!(target: "afg", "Polling round {}, state = {:?}", self.votes.number(), self.votes.state());
+		trace!(target: "afg", "Polling round {}, state = {:?}, step = {:?}", self.votes.number(), self.votes.state(), self.state);
 
 		let pre_state = self.votes.state();
 

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -110,13 +110,13 @@ enum State<T> {
 }
 
 impl<T> std::fmt::Debug for State<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		match self {
 			State::Start(..) => write!(f, "Start"),
 			State::Prevoted(_) => write!(f, "Prevoted"),
 			State::Precommitted => write!(f, "Precommitted"),
 		}
-    }
+	}
 }
 
 struct Buffered<S: Sink> {

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -604,8 +604,6 @@ impl<H, N, E: Environment<H, N>> Committer<H, N, E> where
 	}
 
 	fn process_incoming(&mut self) -> Result<(), E::Error> {
-		// TODO: import commits for rounds that aren't running, i.e. calculate
-		// `precommit_ghost` and finalize that
 		while let Async::Ready(Some(incoming)) = self.incoming.poll()? {
 			// NOTE: we assume the signature for the commit has been checked as
 			// well as all the internal signatures on each precommit


### PR DESCRIPTION
Related #9 #19.

- When a round is completable and we precommitted we start a commit timer and start accepting commit messages;
- When we receive a commit message if it targets a block higher than what we've finalized we validate it and import its precommits if valid;
- When our commit timer triggers we check if we've received any commit message for a block equal to what we've finalized, if we haven't then we broadcast a commit.

Also fixed some unrelated issues with the existing tests.