### PR TITLE
Minor API changes for grandpa 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finality-grandpa"
-version = "0.3.0"
+version = "0.4.0"
 description = "PBFT-based finality gadget for blockchains"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "GPL-3.0"

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -185,8 +185,6 @@ impl ::voter::Environment<&'static str, u32> for Environment {
 	type Signature = Signature;
 	type In = Box<Stream<Item=SignedMessage<&'static str, u32, Signature, Id>,Error=Error> + Send + 'static>;
 	type Out = Box<Sink<SinkItem=Message<&'static str, u32>,SinkError=Error> + Send + 'static>;
-	type CommitIn = Box<Stream<Item=(u64, CompactCommit<&'static str, u32, Signature, Id>), Error=Error> + Send + 'static>;
-	type CommitOut = Box<Sink<SinkItem=(u64, Commit<&'static str, u32, Signature, Id>), SinkError=Error> + Send + 'static>;
 	type Error = Error;
 
 	fn round_data(&self, round: u64) -> RoundData<Self::Timer, Self::In, Self::Out> {
@@ -214,11 +212,6 @@ impl ::voter::Environment<&'static str, u32> for Environment {
 
 		let now = Instant::now();
 		Box::new(Delay::new(now + delay).map_err(|_| panic!("Timer failed")))
-	}
-
-	fn committer_data(&self) -> (Self::CommitIn, Self::CommitOut) {
-		let (incoming, outgoing) = self.network.make_commits_comms();
-		(Box::new(incoming), Box::new(outgoing))
 	}
 
 	fn completed(&self, _round: u64, _state: RoundState<&'static str, u32>) -> Result<(), Error> {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -141,17 +141,15 @@ pub struct Signature(pub u32);
 
 pub struct Environment {
 	chain: Mutex<DummyChain>,
-	voters: HashMap<Id, u64>,
 	local_id: Id,
 	network: Network,
 	listeners: Mutex<Vec<UnboundedSender<(&'static str, u32, Commit<&'static str, u32, Signature, Id>)>>>,
 }
 
 impl Environment {
-	pub fn new(voters: HashMap<Id, u64>, network: Network, local_id: Id) -> Self {
+	pub fn new(network: Network, local_id: Id) -> Self {
 		Environment {
 			chain: Mutex::new(DummyChain::new()),
-			voters,
 			local_id,
 			network,
 			listeners: Mutex::new(Vec::new()),
@@ -191,7 +189,7 @@ impl ::voter::Environment<&'static str, u32> for Environment {
 	type CommitOut = Box<Sink<SinkItem=(u64, Commit<&'static str, u32, Signature, Id>), SinkError=Error> + Send + 'static>;
 	type Error = Error;
 
-	fn round_data(&self, round: u64) -> RoundData<Self::Timer, Self::Id, Self::In, Self::Out> {
+	fn round_data(&self, round: u64) -> RoundData<Self::Timer, Self::In, Self::Out> {
 		const GOSSIP_DURATION: Duration = Duration::from_millis(500);
 
 		let now = Instant::now();
@@ -201,14 +199,9 @@ impl ::voter::Environment<&'static str, u32> for Environment {
 				.map_err(|_| panic!("Timer failed"))),
 			precommit_timer: Box::new(Delay::new(now + GOSSIP_DURATION + GOSSIP_DURATION)
 				.map_err(|_| panic!("Timer failed"))),
-			voters: self.voters.clone(),
 			incoming: Box::new(incoming),
 			outgoing: Box::new(outgoing),
 		}
-	}
-
-	fn voters(&self, _round: u64) -> &HashMap<Self::Id, u64> {
-		&self.voters
 	}
 
 	fn round_commit_timer(&self) -> Self::Timer {

--- a/src/voter.rs
+++ b/src/voter.rs
@@ -765,6 +765,11 @@ impl<H, N, E: Environment<H, N>, CommitIn, CommitOut> Voter<H, N, E, CommitIn, C
 	/// Provide data about the last completed round. If there is no
 	/// known last completed round, the genesis state (round number 0),
 	/// should be provided.
+	///
+	/// The input stream for commit messages should provide commits which
+	/// correspond to known blocks only (including all its precommits). It
+	/// is also responsible for validating the signature data in commit
+	/// messages.
 	pub fn new(
 		env: Arc<E>,
 		voters: HashMap<E::Id, u64>,


### PR DESCRIPTION
Removed `voters` and the commit streams out of `Environment`, these are passed to the `Voter` instead when creating it since they're static through its lifetime. I think I actually prefer having the commit streams declared in the `Environment` since it leads to less type pollution in the definition of the `Committer` and `Voter`.

Ref #30 