### PR TITLE
Pass round on finalization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finality-grandpa"
-version = "0.4.0"
+version = "0.5.0"
 description = "PBFT-based finality gadget for blockchains"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "GPL-3.0"

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -218,7 +218,7 @@ impl ::voter::Environment<&'static str, u32> for Environment {
 		Ok(())
 	}
 
-	fn finalize_block(&self, hash: &'static str, number: u32, commit: Commit<&'static str, u32, Signature, Id>) -> Result<(), Error> {
+	fn finalize_block(&self, hash: &'static str, number: u32, _round: u64, commit: Commit<&'static str, u32, Signature, Id>) -> Result<(), Error> {
 		let mut chain = self.chain.lock();
 
 		if number as u32 <= chain.finalized.1 { panic!("Attempted to finalize backwards") }


### PR DESCRIPTION
This is needed so that later on commit messages can be verified, since precommit signatures are localized to the round number. We should release `0.5.0` with this (used in https://github.com/paritytech/substrate/compare/andre/grandpa-handoff-justification).