### PR TITLE
adjust base in vote_graph

### DIFF
--- a/src/vote_graph.rs
+++ b/src/vote_graph.rs
@@ -135,6 +135,8 @@ impl<H, N, V> VoteGraph<H, N, V> where
 
 		// hack because we can't convert usize -> N, only vice-versa.
 		// hopefully LLVM can optimize.
+		//
+		// TODO: Add TryFrom to `BlockNumberOps`.
 		let new_number = {
 			let mut new_number = self.base_number;
 			for _ in 0..ancestry_proof.len() {


### PR DESCRIPTION
This will be a helpful utility for doing accountable safety proofs; basically when we are answering queries we don't know what the base should be. 

The method will be to start with the block we try to prove impossibility of estimate, and then import historical votes into a `round` until we get `NotDescendent`, and then compute the common ancestor, adjust the base, and continue importing.

Might be useful for `commit` validation as well.