### PR TITLE
update codec to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/paritytech/finality-grandpa"
 parking_lot = "0.4"
 log = "0.4"
 futures = "0.1"
-parity-codec = { version = "2.0", optional = true }
-parity-codec-derive = { version = "2.0", optional = true }
+parity-codec = { version = "3.0", optional = true }
+parity-codec-derive = { version = "3.0", optional = true }
 num-traits = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
this is a breaking change as codec is exposed.
Then we can release a new version so we can use new codec in substrate