### PR TITLE
replace prospective round machinery with catch-up rounds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,7 +497,7 @@ pub fn threshold(total_weight: u64) -> u64 {
 /// good otherwise.
 pub fn process_commit_validation_result<H, N>(
 	validation_result: CommitValidationResult<H, N>,
-	mut callback: voter::Callback,
+	mut callback: voter::Callback<voter::CommitProcessingOutcome>,
 ) {
 	if let Some(_) = validation_result.ghost {
 		callback.run(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,18 @@ pub struct Commit<H, N, S, Id> {
 	pub precommits: Vec<SignedPrecommit<H, N, S, Id>>,
 }
 
+/// A signed prevote message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+pub struct SignedPrevote<H, N, S, Id> {
+	/// The prevote message which has been signed.
+	pub prevote: Prevote<H, N>,
+	/// The signature on the message.
+	pub signature: S,
+	/// The Id of the signer.
+	pub id: Id,
+}
+
 /// A signed precommit message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
@@ -283,12 +295,32 @@ pub struct CompactCommit<H, N, S, Id> {
 	/// Precommits for target block or any block after it that justify this commit.
 	pub precommits: Vec<Precommit<H, N>>,
 	/// Authentication data for the commit.
-	pub auth_data: CommitAuthData<S, Id>,
+	pub auth_data: MultiAuthData<S, Id>,
 }
 
-/// Authentication data for a commit, currently a set of precommit signatures but
+/// A catch-up message, which is an aggregate of prevotes and precommits necessary
+/// to complete a round.
+///
+/// This message contains a "base", which is a block all of the vote-targets are
+/// a descendent of.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+pub struct CatchUp<H, N, S, Id> {
+	/// Round number.
+	pub round_number: u64,
+	/// Prevotes for target block or any block after it that justify this catch-up.
+	pub prevotes: Vec<SignedPrevote<H, N, S, Id>>,
+	/// Precommits for target block or any block after it that justify this catch-up.
+	pub precommits: Vec<SignedPrecommit<H, N, S, Id>>,
+	/// The base hash. See struct docs.
+	pub base_hash: H,
+	/// The base number. See struct docs.
+	pub base_number: N,
+}
+
+/// Authentication data for a set of many messages, currently a set of precommit signatures but
 /// in the future could be optimized with BLS signature aggregation.
-pub type CommitAuthData<S, Id> = Vec<(S, Id)>;
+pub type MultiAuthData<S, Id> = Vec<(S, Id)>;
 
 impl<H, N, S, Id> From<CompactCommit<H, N, S, Id>> for Commit<H, N, S, Id> {
 	fn from(commit: CompactCommit<H, N, S, Id>) -> Commit<H, N, S, Id> {

--- a/src/round.rs
+++ b/src/round.rs
@@ -481,7 +481,6 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 
 		let voters = &self.voters;
 
-
 		let (g_hash, g_num) = match self.prevote_ghost.clone() {
 			None => return,
 			Some(x) => x,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -257,6 +257,10 @@ impl<M: Clone> BroadcastNetwork<M> {
 		}
 	}
 
+	pub fn send_message(&self, message: M) {
+		let _ = self.raw_sender.unbounded_send(message);
+	}
+
 	// add a node to the network for a round.
 	fn add_node<N, F: Fn(N) -> M>(&mut self, f: F) -> (
 		impl Stream<Item=M,Error=Error>,
@@ -341,6 +345,11 @@ impl Network {
 			CommunicationOut::Commit(r, commit) => CommunicationIn::Commit(r, commit.into()),
 			CommunicationOut::Auxiliary(aux) => CommunicationIn::Auxiliary(aux),
 		})
+	}
+
+	/// Send a message to all nodes.
+	pub fn send_message(&self, message: CommunicationIn<&'static str, u32, Signature, Id>) {
+		self.global_messages.lock().send_message(message);
 	}
 }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -360,7 +360,6 @@ impl Network {
 		let mut global_messages = self.global_messages.lock();
 		global_messages.add_node(|message| match message {
 			CommunicationOut::Commit(r, commit) => CommunicationIn::Commit(r, commit.into(), Callback::Blank),
-			CommunicationOut::Auxiliary(aux) => CommunicationIn::Auxiliary(aux),
 		})
 	}
 

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -514,6 +514,11 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 
 						for prevote in &catch_up.prevotes {
 							if !voters.contains_key(&prevote.id) {
+								trace!(target: "afg",
+									"Ignoring invalid catch up, invalid voter: {:?}",
+									prevote.id,
+								);
+
 								process_catch_up_outcome.run(CatchUpProcessingOutcome::Bad(BadCatchUp::new()));
 								return Ok(())
 							}
@@ -522,6 +527,11 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 
 						for precommit in &catch_up.precommits {
 							if !voters.contains_key(&precommit.id) {
+								trace!(target: "afg",
+									"Ignoring invalid catch up, invalid voter: {:?}",
+									precommit.id,
+								);
+
 								process_catch_up_outcome.run(CatchUpProcessingOutcome::Bad(BadCatchUp::new()));
 								return Ok(())
 							}
@@ -547,6 +557,10 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 
 						let threshold = voters.threshold();
 						if pv < threshold || pc < threshold {
+							trace!(target: "afg",
+								"Ignoring invalid catch up, missing voter threshold"
+							);
+
 							process_catch_up_outcome.run(CatchUpProcessingOutcome::Bad(BadCatchUp::new()));
 							return Ok(())
 						}
@@ -563,6 +577,11 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 						match round.import_prevote(&*self.env, prevote, id, signature) {
 							Ok(_) => {},
 							Err(e) => {
+								trace!(target: "afg",
+									"Ignoring invalid catch up, error importing prevote: {:?}",
+									e,
+								);
+
 								process_catch_up_outcome.run(CatchUpProcessingOutcome::Bad(BadCatchUp::new()));
 								return Ok(());
 							},
@@ -574,6 +593,11 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 						match round.import_precommit(&*self.env, precommit, id, signature) {
 							Ok(_) => {},
 							Err(e) => {
+								trace!(target: "afg",
+									"Ignoring invalid catch up, error importing precommit: {:?}",
+									e,
+								);
+
 								process_catch_up_outcome.run(CatchUpProcessingOutcome::Bad(BadCatchUp::new()));
 								return Ok(());
 							},

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -241,7 +241,8 @@ impl<O> Clone for Callback<O> {
 }
 
 impl<O> Callback<O> {
-	pub(crate) fn run(&mut self, o: O) {
+	/// Do the work associated with the callback, if any.
+	pub fn run(&mut self, o: O) {
 		match self {
 			Callback::Blank => {},
 			Callback::Work(cb) => cb(o),

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -648,9 +648,6 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 
 					self.past_rounds.push(&*self.env, just_completed);
 
-					// stop voting in the best round before we background it, just in case it contradicts what
-					// we're doing now.
-					self.best_round.stop_voting();
 					self.past_rounds.push(
 						&*self.env,
 						std::mem::replace(&mut self.best_round, new_best),

--- a/src/voter/past_rounds.rs
+++ b/src/voter/past_rounds.rs
@@ -60,8 +60,13 @@ impl<H, N, E: Environment<H, N>> BackgroundRound<H, N, E> where
 
 	fn is_done(&self) -> bool {
 		// no need to listen on a round anymore once the estimate is finalized.
+		//
+		// we map `None` to true because
+		//   - rounds are not backgrounded when incomplete unless we've skipped forward
+		//   - if we skipped forward we may never complete this round and we don't need
+		//     to keep it forever.
 		self.round_committer.is_none() && self.inner.round_state().estimate
-			.map_or(false, |x| (x.1) <= self.finalized_number)
+			.map_or(true, |x| x.1 <= self.finalized_number)
 	}
 
 	fn update_finalized(&mut self, new_finalized: N) {

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -169,9 +169,15 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 	pub(super) fn round_number(&self) -> u64 {
 		self.votes.number()
 	}
+
 	/// Get the round state.
 	pub(super) fn round_state(&self) -> RoundState<H, N> {
 		self.votes.state()
+	}
+
+	/// Get the base block in the dag.
+	pub(super) fn dag_base(&self) -> (H, N) {
+		self.votes.base()
 	}
 
 	/// Get the voters in this round.

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -276,11 +276,6 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		latter_view
 	}
 
-	// call this to bridge state from another around.
-	pub(super) fn bridge_state_from(&mut self, other: &mut Self) {
-		self.last_round_state = Some(other.bridge_state())
-	}
-
 	/// Get a commit justifying the best finalized block.
 	pub(super) fn finalizing_commit(&self) -> Option<&Commit<H, N, E::Signature, E::Id>> {
 		self.best_finalized.as_ref()

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -161,7 +161,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 			voting: Voting::No,
 			incoming: round_data.incoming,
 			outgoing: Buffered::new(round_data.outgoing),
-			state: Some(State::Precommitted), // so we don't vote anymore.
+			state: None,
 			bridged_round_state: None,
 			primary_block: None,
 			env,
@@ -174,7 +174,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 	/// Mark the round as no-further-voting. Rounds that are in this state will not be
 	/// voted on any more. Irreversible.
 	pub(super) fn stop_voting(&mut self) {
-		self.state = Some(State::Precommitted);
+		self.voting = Voting::No;
 	}
 
 	/// Poll the round. When the round is completable and messages have been flushed, it will return `Async::Ready` but

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -176,12 +176,6 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		}
 	}
 
-	/// Mark the round as no-further-voting. Rounds that are in this state will not be
-	/// voted on any more. Irreversible.
-	pub(super) fn stop_voting(&mut self) {
-		self.voting = Voting::No;
-	}
-
 	/// Poll the round. When the round is completable and messages have been flushed, it will return `Async::Ready` but
 	/// can continue to be polled.
 	pub(super) fn poll(&mut self) -> Poll<(), E::Error> {
@@ -286,7 +280,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		self.best_finalized.as_ref()
 	}
 
-	/// Return all votes for the round (prevotes and precommits), 
+	/// Return all votes for the round (prevotes and precommits),
 	/// sorted by imported order and indicating the indices where we voted.
 	pub(super) fn historical_votes(&self) -> &HistoricalVotes<H, N, E::Signature, E::Id> {
 		self.votes.historical_votes()


### PR DESCRIPTION
The existing process for catching up to the current round when behind followed these steps:
  - Watch for future commit messages
  - After a future commit, start a "prospective" round running in parallel to the best round we've currently got
  - If we see this prospective round conclude, we set our best round to be prospective + 1.

Replaces with catch-up rounds (#47). Logic for constructing and requesting catch-up rounds isn't yet implemented, but importing is done.