### PR TITLE
Add callbacks to commit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,6 +335,8 @@ impl<H: Clone, N: Clone, S, Id> From<Commit<H, N, S, Id>> for CompactCommit<H, N
 	}
 }
 
+/// Struct returned from `validate_commit` function with information
+/// about the validation result.
 pub struct CommitValidationResult<H, N> {
 	ghost: Option<(H, N)>,
 	num_duplicated_precommits: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,6 +339,7 @@ impl<H: Clone, N: Clone, S, Id> From<Commit<H, N, S, Id>> for CompactCommit<H, N
 /// about the validation result.
 pub struct CommitValidationResult<H, N> {
 	ghost: Option<(H, N)>,
+	num_precommits: usize,
 	num_duplicated_precommits: usize,
 	num_equivocations: usize,
 	num_invalid_voters: usize,
@@ -348,6 +349,7 @@ impl<H, N> Default for CommitValidationResult<H, N> {
 	fn default() -> Self {
 		CommitValidationResult {
 			ghost: None,
+			num_precommits: 0,
 			num_duplicated_precommits: 0,
 			num_equivocations: 0,
 			num_invalid_voters: 0,
@@ -375,6 +377,7 @@ pub fn validate_commit<H, N, S, I, C: Chain<H, N>>(
 	S: Eq,
 {
 	let mut validation_result = CommitValidationResult::default();
+	validation_result.num_precommits = commit.precommits.len();
 
 	// check that all precommits are for blocks higher than the target
 	// commit block, and that they're its descendents

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,8 +344,8 @@ pub struct CommitValidationResult<H, N> {
 	num_invalid_voters: usize,
 }
 
-impl<H, N> CommitValidationResult<H, N> {
-	fn new() -> Self {
+impl<H, N> Default for CommitValidationResult<H, N> {
+	fn default() -> Self {
 		CommitValidationResult {
 			ghost: None,
 			num_duplicated_precommits: 0,
@@ -374,7 +374,7 @@ pub fn validate_commit<H, N, S, I, C: Chain<H, N>>(
 	I: Clone + std::hash::Hash + Eq + std::fmt::Debug,
 	S: Eq,
 {
-	let mut validation_result = CommitValidationResult::new();
+	let mut validation_result = CommitValidationResult::default();
 
 	// check that all precommits are for blocks higher than the target
 	// commit block, and that they're its descendents

--- a/src/round.rs
+++ b/src/round.rs
@@ -84,8 +84,6 @@ enum VoteMultiplicity<Vote, Signature> {
 	Equivocated((Vote, Signature), (Vote, Signature)),
 }
 
-
-
 impl<Vote: Eq, Signature: Eq> VoteMultiplicity<Vote, Signature> {
 	fn contains(&self, vote: &Vote, signature: &Signature) -> bool {
 		match self {
@@ -119,7 +117,7 @@ impl<Id: Hash + Eq + Clone, Vote: Clone + Eq, Signature: Clone + Eq> VoteTracker
 	}
 
 	// track a vote, returning a value containing the multiplicity of all votes from this ID
-	// and a boolean indicating if the vote is duplicated.
+	// and a bool indicating if the vote is duplicated.
 	// if the vote is the first equivocation, returns a value indicating
 	// it as such (the new vote is always the last in the multiplicity).
 	//

--- a/src/round.rs
+++ b/src/round.rs
@@ -110,7 +110,8 @@ impl<Id: Hash + Eq + Clone, Vote: Clone + Eq, Signature: Clone + Eq> VoteTracker
 		}
 	}
 
-	// track a vote, returning a value containing the multiplicity of all votes from this ID.
+	// track a vote, returning a value containing the multiplicity of all votes from this ID
+	// and a boolean indicating if the vote is duplicated.
 	// if the vote is the first equivocation, returns a value indicating
 	// it as such (the new vote is always the last in the multiplicity).
 	//

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -311,6 +311,7 @@ type RoundNetwork = BroadcastNetwork<SignedMessage<&'static str, u32, Signature,
 type GlobalMessageNetwork = BroadcastNetwork<CommunicationIn<&'static str, u32, Signature, Id, fn(CommitProcessingOutcome)>>;
 
 /// A test network. Instantiate this with `make_network`,
+#[derive(Clone)]
 pub struct Network {
 	rounds: Arc<Mutex<HashMap<u64, RoundNetwork>>>,
 	global_messages: Arc<Mutex<GlobalMessageNetwork>>,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -317,8 +317,7 @@ pub struct Network {
 	global_messages: Arc<Mutex<GlobalMessageNetwork>>,
 }
 
-impl Network
-{
+impl Network {
 	pub fn make_round_comms(&self, round_number: u64, node_id: Id) -> (
 		impl Stream<Item=SignedMessage<&'static str, u32, Signature, Id>,Error=Error>,
 		impl Sink<SinkItem=Message<&'static str, u32>,SinkError=Error>

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::time::{Instant, Duration};
 
 use crate::round::State as RoundState;
-use crate::voter::{RoundData, CommunicationIn, CommunicationOut, Callback, CommitProcessingOutcome};
+use crate::voter::{RoundData, CommunicationIn, CommunicationOut, Callback};
 use tokio::timer::Delay;
 use parking_lot::Mutex;
 use futures::prelude::*;
@@ -308,7 +308,7 @@ pub fn make_network() -> (Network, NetworkRouting) {
 }
 
 type RoundNetwork = BroadcastNetwork<SignedMessage<&'static str, u32, Signature, Id>>;
-type GlobalMessageNetwork = BroadcastNetwork<CommunicationIn<&'static str, u32, Signature, Id, fn(CommitProcessingOutcome)>>;
+type GlobalMessageNetwork = BroadcastNetwork<CommunicationIn<&'static str, u32, Signature, Id>>;
 
 /// A test network. Instantiate this with `make_network`,
 #[derive(Clone)]
@@ -334,7 +334,7 @@ impl Network
 	}
 
 	pub fn make_global_comms(&self) -> (
-		impl Stream<Item=CommunicationIn<&'static str, u32, Signature, Id, fn(CommitProcessingOutcome)>,Error=Error>,
+		impl Stream<Item=CommunicationIn<&'static str, u32, Signature, Id>,Error=Error>,
 		impl Sink<SinkItem=CommunicationOut<&'static str, u32, Signature, Id>,SinkError=Error>
 	) {
 		let mut global_messages = self.global_messages.lock();

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -106,11 +106,17 @@ pub enum CommunicationOut<H, N, S, Id> {
 	Auxiliary(AuxiliaryCommunication<H, N, Id>),
 }
 
+/// Number of precommits in the commit. 
+/// More commits imply a worst outcome because of the processing time.
+type NumOfPrecommits = usize;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
 pub enum CommitProcessingOutcome {
+	/// It was beneficial to process this commit.
 	Good,
-	Bad,
+	/// It wasn't beneficial to process this commit. We wasted resources.
+	Bad(NumOfPrecommits),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -412,7 +418,7 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut, F> Voter<H, N, E, GlobalIn
 							call_with(process_commit_outcome, CommitProcessingOutcome::Good);
 						} else {
 							// Failing validation of a commit is bad.
-							call_with(process_commit_outcome, CommitProcessingOutcome::Bad);
+							call_with(process_commit_outcome, CommitProcessingOutcome::Bad(commit.precommits.len()));
 						}
 					} else {
 						// Import to backgrounded round is good.

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -162,6 +162,7 @@ impl BadCommit {
 	}
 }
 
+/// Callback used to propagate the commit in case the outcome is good.
 #[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
 pub enum Callback {
 	/// Default value.

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -136,7 +136,7 @@ impl GoodCommit {
 pub struct BadCommit {
 	_priv: (), // lets us add stuff without breaking API.
 	num_precommits: usize,
-	duplicated_precommits: usize,
+	num_duplicated_precommits: usize,
 }
 
 impl BadCommit {
@@ -147,7 +147,7 @@ impl BadCommit {
 
 	/// Get the number of duplicated precommits
 	pub fn num_duplicated(&self) -> usize {
-		self.duplicated_precommits
+		self.num_duplicated_precommits
 	}
 }
 
@@ -461,7 +461,7 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 							process_commit_outcome.run(
 								CommitProcessingOutcome::Bad(BadCommit {
 									num_precommits: commit.precommits.len(),
-									num_precommits_duplicated: num_duplicated_precommits,
+									num_duplicated_precommits: num_duplicated_precommits,
 									_priv: (),
 								}),
 							);

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -151,7 +151,7 @@ pub enum Callback {
 	/// Default value.
 	Blank,
 	/// Callback to execute given a commit processing outcome.
-	Work(Box<Fn(CommitProcessingOutcome) + Send>),
+	Work(Box<FnMut(CommitProcessingOutcome) + Send>),
 }
 
 impl Clone for Callback {
@@ -418,7 +418,7 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 					let commit: Commit<_, _, _, _> = commit.into();
 
 					let call_with = |callback: Callback, outcome| {
-						if let Callback::Work(with_call) = callback {
+						if let Callback::Work(mut with_call) = callback {
 							(with_call)(outcome);
 						}
 					};

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -136,13 +136,18 @@ impl GoodCommit {
 pub struct BadCommit {
 	_priv: (), // lets us add stuff without breaking API.
 	num_precommits: usize,
-	num_precommits_duplicated: usize,
+	duplicated_precommits: usize,
 }
 
 impl BadCommit {
 	/// Get the number of precommits
 	pub fn num_precommits(&self) -> usize {
 		self.num_precommits
+	}
+
+	/// Get the number of duplicated precommits
+	pub fn num_duplicated(&self) -> usize {
+		self.duplicated_precommits
 	}
 }
 

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -166,7 +166,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		&mut self,
 		commit: &Commit<H, N, E::Signature, E::Id>
 	) -> Result<Option<(H, N)>, E::Error> {
-		let (base, _) = validate_commit(&commit, self.voters(), &*self.env)?;
+		let base = validate_commit(&commit, self.voters(), &*self.env)?.ghost;
 		if base.is_none() { return Ok(None) }
 
 		for SignedPrecommit { precommit, signature, id } in commit.precommits.iter().cloned() {

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -229,7 +229,6 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 					}
 				}
 				Message::Precommit(precommit) => {
-
 					let import_result = self.votes.import_precommit(&*self.env, precommit, id, signature)?;
 					if let ImportResult { equivocation: Some(e), .. } = import_result {
 						self.env.precommit_equivocation(self.votes.number(), e);

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use crate::round::{Round, State as RoundState};
 use crate::{
 	Commit, Message, Prevote, Precommit, PrimaryPropose, SignedMessage,
-	SignedPrecommit, BlockNumberOps, validate_commit
+	SignedPrecommit, BlockNumberOps, validate_commit, ImportResult,
 };
 use crate::voter_set::VoterSet;
 use super::{Environment, Buffered};
@@ -170,7 +170,8 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		if base.is_none() { return Ok(None) }
 
 		for SignedPrecommit { precommit, signature, id } in commit.precommits.iter().cloned() {
-			if let (Some(e), _) = self.votes.import_precommit(&*self.env, precommit, id, signature)? {
+			let import_result = self.votes.import_precommit(&*self.env, precommit, id, signature)?;
+			if let ImportResult { equivocation: Some(e), .. } = import_result {
 				self.env.precommit_equivocation(self.round_number(), e);
 			}
 		}
@@ -222,12 +223,15 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 
 			match message {
 				Message::Prevote(prevote) => {
-					if let (Some(e), _) = self.votes.import_prevote(&*self.env, prevote, id, signature)? {
+					let import_result = self.votes.import_prevote(&*self.env, prevote, id, signature)?;
+					if let ImportResult { equivocation: Some(e), .. } = import_result {
 						self.env.prevote_equivocation(self.votes.number(), e);
 					}
 				}
 				Message::Precommit(precommit) => {
-					if let (Some(e), _) = self.votes.import_precommit(&*self.env, precommit, id, signature)? {
+
+					let import_result = self.votes.import_precommit(&*self.env, precommit, id, signature)?;
+					if let ImportResult { equivocation: Some(e), .. } = import_result {
 						self.env.precommit_equivocation(self.votes.number(), e);
 					}
 				}

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -166,11 +166,11 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		&mut self,
 		commit: &Commit<H, N, E::Signature, E::Id>
 	) -> Result<Option<(H, N)>, E::Error> {
-		let base = validate_commit(&commit, self.voters(), &*self.env)?;
+		let (base, _) = validate_commit(&commit, self.voters(), &*self.env)?;
 		if base.is_none() { return Ok(None) }
 
 		for SignedPrecommit { precommit, signature, id } in commit.precommits.iter().cloned() {
-			if let Some(e) = self.votes.import_precommit(&*self.env, precommit, id, signature)? {
+			if let (Some(e), _) = self.votes.import_precommit(&*self.env, precommit, id, signature)? {
 				self.env.precommit_equivocation(self.round_number(), e);
 			}
 		}
@@ -222,12 +222,12 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 
 			match message {
 				Message::Prevote(prevote) => {
-					if let Some(e) = self.votes.import_prevote(&*self.env, prevote, id, signature)? {
+					if let (Some(e), _) = self.votes.import_prevote(&*self.env, prevote, id, signature)? {
 						self.env.prevote_equivocation(self.votes.number(), e);
 					}
 				}
 				Message::Precommit(precommit) => {
-					if let Some(e) = self.votes.import_precommit(&*self.env, precommit, id, signature)? {
+					if let (Some(e), _) = self.votes.import_precommit(&*self.env, precommit, id, signature)? {
 						self.env.precommit_equivocation(self.votes.number(), e);
 					}
 				}


### PR DESCRIPTION
PR for issue #55 

- Add several structs to save information from commit importing logic.
- Add callback enum to execute code that propagates the commit in case the information gathered is good.