### PR TITLE
Answer queries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,10 +481,10 @@ pub fn process_commit_validation_result<H, N>(
 /// Historical votes seen in a round.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
-pub struct HistoricalVotes<M> {
-	seen: Vec<M>,
-	prevote_idx: usize,
-	precommit_idx: usize,
+pub struct HistoricalVotes<H, N> {
+	seen: Vec<Message<H, N>>,
+	prevote_idx: Option<usize>,
+	precommit_idx: Option<usize>,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,6 +478,15 @@ pub fn process_commit_validation_result<H, N>(
 	}
 }
 
+/// Historical votes seen in a round.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+pub struct HistoricalVotes<M> {
+	seen: Vec<M>,
+	prevote_idx: usize,
+	precommit_idx: usize,
+}
+
 #[cfg(test)]
 mod tests {
 	use super::threshold;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,7 +488,7 @@ pub struct HistoricalVotes<H, N, S, Id> {
 }
 
 impl<H, N, S, Id> HistoricalVotes<H, N, S, Id> {
-	/// Creates a new HistoricalVotes.
+	/// Create a new HistoricalVotes.
 	pub fn new() -> Self {
 		HistoricalVotes {
 			seen: Vec::new(),
@@ -497,30 +497,49 @@ impl<H, N, S, Id> HistoricalVotes<H, N, S, Id> {
 		}
 	}
 
-	/// Creates a new HistoricalVotes initialized with messages in `seen`.
-	pub fn new_with_votes(seen: Vec<SignedMessage<H, N, S, Id>>) -> Self {
+	/// Create a new HistoricalVotes initialized from the parameters.
+	pub fn new_with(
+		seen: Vec<SignedMessage<H, N, S, Id>>,
+		prevote_idx: Option<usize>,
+		precommit_idx: Option<usize>
+	) -> Self {
 		HistoricalVotes {
 			seen,
-			prevote_idx: None,
-			precommit_idx: None,
+			prevote_idx,
+			precommit_idx,
 		}
 	}
 
-	/// Returns the messages seen so far.
+	/// Push a vote into the list.
+	pub fn push_vote(&mut self, msg: SignedMessage<H, N, S, Id>) {
+		self.seen.push(msg)
+	}
+
+	/// Return the messages seen so far.
 	pub fn seen(&self) -> &Vec<SignedMessage<H, N, S, Id>> {
 		&self.seen
 	}
 
-	/// Returns the number of messages seen before prevoting.
-	/// Returns None in case we didn't prevote yet.
+	/// Return the number of messages seen before prevoting.
+	/// None in case we didn't prevote yet.
 	pub fn prevote_idx(&self) -> Option<usize> {
 		self.prevote_idx
 	}
 
-	/// Returns the number of messages seen before precommiting.
-	/// Returns None in case we didn't precommit yet.
+	/// Return the number of messages seen before precommiting.
+	/// None in case we didn't precommit yet.
 	pub fn precommit_idx(&self) -> Option<usize> {
 		self.precommit_idx
+	}
+
+	/// Set the number of messages seen before prevoting.
+	pub fn set_prevoted_idx(&mut self) {
+		self.prevote_idx = Some(self.seen.len())
+	}
+
+	/// Set the number of messages seen before precommiting.
+	pub fn set_precommited_idx(&mut self) {
+		self.precommit_idx = Some(self.seen.len())
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,6 +487,16 @@ pub struct HistoricalVotes<H, N> {
 	precommit_idx: Option<usize>,
 }
 
+impl<H, N> HistoricalVotes<H, N> {
+	pub fn new() -> Self {
+		HistoricalVotes {
+			seen: Vec::new(),
+			prevote_idx: None,
+			precommit_idx: None,
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::threshold;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,6 +488,7 @@ pub struct HistoricalVotes<H, N, S, Id> {
 }
 
 impl<H, N, S, Id> HistoricalVotes<H, N, S, Id> {
+	/// Creates a new HistoricalVotes.
 	pub fn new() -> Self {
 		HistoricalVotes {
 			seen: Vec::new(),
@@ -496,6 +497,7 @@ impl<H, N, S, Id> HistoricalVotes<H, N, S, Id> {
 		}
 	}
 
+	/// Creates a new HistoricalVotes initialized with messages in `seen`.
 	pub fn new_with_votes(seen: Vec<SignedMessage<H, N, S, Id>>) -> Self {
 		HistoricalVotes {
 			seen,
@@ -504,14 +506,19 @@ impl<H, N, S, Id> HistoricalVotes<H, N, S, Id> {
 		}
 	}
 
+	/// Returns the messages seen so far.
 	pub fn seen(&self) -> &Vec<SignedMessage<H, N, S, Id>> {
 		&self.seen
 	}
 
+	/// Returns the number of messages seen before prevoting.
+	/// Returns None in case we didn't prevote yet.
 	pub fn prevote_idx(&self) -> Option<usize> {
 		self.prevote_idx
 	}
 
+	/// Returns the number of messages seen before precommiting.
+	/// Returns None in case we didn't precommit yet.
 	pub fn precommit_idx(&self) -> Option<usize> {
 		self.precommit_idx
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,13 +481,13 @@ pub fn process_commit_validation_result<H, N>(
 /// Historical votes seen in a round.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
-pub struct HistoricalVotes<H, N> {
-	seen: Vec<Message<H, N>>,
+pub struct HistoricalVotes<H, N, S, Id> {
+	seen: Vec<SignedMessage<H, N, S, Id>>,
 	prevote_idx: Option<usize>,
 	precommit_idx: Option<usize>,
 }
 
-impl<H, N> HistoricalVotes<H, N> {
+impl<H, N, S, Id> HistoricalVotes<H, N, S, Id> {
 	pub fn new() -> Self {
 		HistoricalVotes {
 			seen: Vec::new(),
@@ -496,7 +496,7 @@ impl<H, N> HistoricalVotes<H, N> {
 		}
 	}
 
-	pub fn seen(&self) -> &Vec<Message<H, N>> {
+	pub fn seen(&self) -> &Vec<SignedMessage<H, N, S, Id>> {
 		&self.seen
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,6 +495,18 @@ impl<H, N> HistoricalVotes<H, N> {
 			precommit_idx: None,
 		}
 	}
+
+	pub fn seen(&self) -> &Vec<Message<H, N>> {
+		&self.seen
+	}
+
+	pub fn prevote_idx(&self) -> Option<usize> {
+		self.prevote_idx
+	}
+
+	pub fn precommit_idx(&self) -> Option<usize> {
+		self.precommit_idx
+	}
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,6 +496,14 @@ impl<H, N, S, Id> HistoricalVotes<H, N, S, Id> {
 		}
 	}
 
+	pub fn new_with_votes(seen: Vec<SignedMessage<H, N, S, Id>>) -> Self {
+		HistoricalVotes {
+			seen,
+			prevote_idx: None,
+			precommit_idx: None,
+		}
+	}
+
 	pub fn seen(&self) -> &Vec<SignedMessage<H, N, S, Id>> {
 		&self.seen
 	}

--- a/src/round.rs
+++ b/src/round.rs
@@ -98,6 +98,7 @@ impl<Vote: Eq, Signature: Eq> VoteMultiplicity<Vote, Signature> {
 struct VoteTracker<Id: Hash + Eq, Vote, Signature> {
 	votes: HashMap<Id, VoteMultiplicity<Vote, Signature>>,
 	current_weight: u64,
+	voted_at: Option<usize>,
 }
 
 /// Result of adding a vote.
@@ -111,6 +112,7 @@ impl<Id: Hash + Eq + Clone, Vote: Clone + Eq, Signature: Clone + Eq> VoteTracker
 		VoteTracker {
 			votes: HashMap::new(),
 			current_weight: 0,
+			voted_at: None,
 		}
 	}
 
@@ -673,6 +675,20 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 	/// Return all imported precommits.
 	pub fn precommits(&self) -> Vec<(Id, Precommit<H, N>, Signature)> {
 		self.precommit.votes()
+	}
+
+	/// Save the len of prevotes received at the moment of prevoting.
+	pub fn set_prevote_idx(&mut self) -> bool {
+		self.prevote.voted_at = Some(self.prevote.votes().len());
+		println!("set prevote idx to {:?}", self.prevote.voted_at);
+		true
+	}
+
+	/// Save the len of precommits received at the moment of precommiting.
+	pub fn set_precommit_idx(&mut self) -> bool {
+		self.precommit.voted_at = Some(self.precommit.votes().len());
+		println!("set precommit idx to {:?}", self.precommit.voted_at);
+		true
 	}
 }
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -173,7 +173,8 @@ impl<Id: Hash + Eq + Clone, Vote: Clone + Eq, Signature: Clone + Eq> VoteTracker
 	// Returns all imported votes.
 	fn votes(&self) -> Vec<(Id, Vote, Signature)> {
 		let mut votes = Vec::new();
-
+		// TODO: I think it should be faster to initialized votes to default values
+		// and then do votes[n] = (). But i need to find the default...
 		for (id, vote) in self.votes.iter() {
 			match vote {
 				VoteMultiplicity::Single(v, s, n) => {

--- a/src/round.rs
+++ b/src/round.rs
@@ -322,22 +322,22 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 			let round_number = self.round_number;
 
 			match multiplicity {
-				VoteMultiplicity::Single(ref vote, _) => {
+				VoteMultiplicity::Single(single_vote, _) => {
 					let vote_weight = VoteWeight {
 						bitfield: self.bitfield_context.prevote_bitfield(info)
 							.expect("info is instantiated from same voter set as context; qed"),
 					};
 
 					self.graph.insert(
-						vote.target_hash.clone(),
-						vote.target_number,
+						single_vote.target_hash.clone(),
+						single_vote.target_number,
 						vote_weight,
 						chain,
 					)?;
 
 					// Push the vote into HistoricalVotes.
-					let message = Message::Prevote(vote.clone());
-					let signed_message = SignedMessage { id: signer.clone(), signature, message };
+					let message = Message::Prevote(vote);
+					let signed_message = SignedMessage { id: signer, signature, message };
 					self.historical_votes.push_vote(signed_message);
 
 					None
@@ -409,25 +409,25 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 			let round_number = self.round_number;
 
 			match multiplicity {
-				VoteMultiplicity::Single(ref vote, _) => {
+				VoteMultiplicity::Single(single_vote, _) => {
 					let vote_weight = VoteWeight {
 						bitfield: self.bitfield_context.precommit_bitfield(info)
 							.expect("info is instantiated from same voter set as context; qed"),
 					};
 
 					self.graph.insert(
-						vote.target_hash.clone(),
-						vote.target_number,
+						single_vote.target_hash.clone(),
+						single_vote.target_number,
 						vote_weight,
 						chain,
 					)?;
 
-					let message = Message::Precommit(vote.clone());
-					let signed_message = SignedMessage { id: signer.clone(), signature, message };
+					let message = Message::Precommit(vote);
+					let signed_message = SignedMessage { id: signer, signature, message };
 					self.historical_votes.push_vote(signed_message);
 
 					None
-				}
+				},
 				VoteMultiplicity::Equivocated(ref first, ref second) => {
 					// mark the equivocator as such. no need to "undo" the first vote.
 					self.bitfield_context.equivocated_precommit(info)
@@ -444,7 +444,7 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 						first: first.clone(),
 						second: second.clone(),
 					})
-				}
+				},
 			}
 		};
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -284,11 +284,7 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 			graph: VoteGraph::new(base_hash, base_number),
 			prevote: VoteTracker::new(),
 			precommit: VoteTracker::new(),
-			historical_votes: HistoricalVotes {
-				seen: Vec::new(),
-				prevote_idx: None,
-				precommit_idx: None,
-			},
+			historical_votes: HistoricalVotes::new(),
 			bitfield_context: BitfieldContext::new(n_validators),
 			prevote_ghost: None,
 			precommit_ghost: None,

--- a/src/round.rs
+++ b/src/round.rs
@@ -1017,8 +1017,8 @@ mod tests {
 					id: "Eve"
 				},
 				SignedMessage {
-					message: Message::Precommit(
-						Precommit { target_hash: "EC", target_number: 10 }
+					message: Message::Prevote(
+						Prevote { target_hash: "EC", target_number: 10 }
 					),
 					signature: Signature("Alice"),
 					id: "Alice"

--- a/src/round.rs
+++ b/src/round.rs
@@ -677,18 +677,28 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		self.precommit.votes()
 	}
 
-	/// Save the len of prevotes received at the moment of prevoting.
+	/// Set the length of prevotes received at the moment of prevoting.
 	pub fn set_prevote_idx(&mut self) -> bool {
 		self.prevote.voted_at = Some(self.prevote.votes().len());
 		println!("set prevote idx to {:?}", self.prevote.voted_at);
 		true
 	}
 
-	/// Save the len of precommits received at the moment of precommiting.
+	/// Set the length of precommits received at the moment of precommiting.
 	pub fn set_precommit_idx(&mut self) -> bool {
 		self.precommit.voted_at = Some(self.precommit.votes().len());
 		println!("set precommit idx to {:?}", self.precommit.voted_at);
 		true
+	}
+
+		/// Get the length of prevotes received at the moment of prevoting.
+	pub fn prevote_idx(&self) -> Option<usize> {
+		self.prevote.voted_at
+	}
+
+	/// Get the length of precommits received at the moment of precommiting.
+	pub fn precommit_idx(&self) -> Option<usize> {
+		self.precommit.voted_at
 	}
 }
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -689,13 +689,13 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 
 	/// Set the length of prevotes and precommits received at the moment of prevoting.
 	pub fn set_prevoted_indices(&mut self) {
-		self.prevoted_indices = Some((self.prevote.votes().len(), self.precommit.votes().len()));
+		self.prevoted_indices = Some((self.prevote.num_votes, self.precommit.num_votes));
 		println!("set prevoted indices to {:?}", self.prevoted_indices)
 	}
 
 	/// Set the length of prevotes and precommits received at the moment of precommiting.
 	pub fn set_precommited_indices(&mut self) {
-		self.precommited_indices = Some((self.prevote.votes().len(), self.precommit.votes().len()));
+		self.precommited_indices = Some((self.prevote.num_votes, self.precommit.num_votes));
 		println!("set precommited indices to {:?}", self.precommited_indices)
 	}
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -24,7 +24,7 @@ use tokio::timer::Delay;
 use parking_lot::Mutex;
 use futures::prelude::*;
 use futures::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use super::{Chain, Commit, Error, Equivocation, Message, Prevote, Precommit, PrimaryPropose, SignedMessage};
+use super::{Chain, Commit, Error, Equivocation, Message, Prevote, Precommit, PrimaryPropose, SignedMessage, HistoricalVotes};
 
 pub const GENESIS_HASH: &str = "genesis";
 const NULL_HASH: &str = "NULL";
@@ -216,7 +216,7 @@ impl crate::voter::Environment<&'static str, u32> for Environment {
 		_round: u64,
 		_state: RoundState<&'static str, u32>,
 		_base: (&'static str, u32),
-		_votes: Vec<SignedMessage<&'static str, u32, Signature, Id>>,
+		_votes: &HistoricalVotes<&'static str, u32>,
 	) -> Result<(), Error> {
 		Ok(())
 	}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -24,7 +24,7 @@ use tokio::timer::Delay;
 use parking_lot::Mutex;
 use futures::prelude::*;
 use futures::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use super::{Chain, Commit, Error, Equivocation, Message, Prevote, Precommit, PrimaryPropose, SignedMessage};
+use super::{Chain, Commit, Error, Equivocation, Message, Prevote, Precommit, PrimaryPropose, SignedMessage, HistoricalVotes};
 
 pub const GENESIS_HASH: &str = "genesis";
 const NULL_HASH: &str = "NULL";
@@ -53,8 +53,6 @@ impl DummyChain {
 	}
 
 	pub fn push_blocks(&mut self, mut parent: &'static str, blocks: &[&'static str]) {
-		use std::cmp::Ord;
-
 		if blocks.is_empty() { return }
 
 		let base_number = self.inner.get(parent).unwrap().number + 1;
@@ -218,7 +216,7 @@ impl crate::voter::Environment<&'static str, u32> for Environment {
 		_round: u64,
 		_state: RoundState<&'static str, u32>,
 		_base: (&'static str, u32),
-		_votes: Vec<SignedMessage<&'static str, u32, Signature, Id>>,
+		_votes: HistoricalVotes<SignedMessage<&'static str, u32, Signature, Id>>,
 	) -> Result<(), Error> {
 		Ok(())
 	}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -216,7 +216,7 @@ impl crate::voter::Environment<&'static str, u32> for Environment {
 		_round: u64,
 		_state: RoundState<&'static str, u32>,
 		_base: (&'static str, u32),
-		_votes: &HistoricalVotes<&'static str, u32>,
+		_votes: &HistoricalVotes<&'static str, u32, Self::Signature, Self::Id>,
 	) -> Result<(), Error> {
 		Ok(())
 	}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -24,7 +24,7 @@ use tokio::timer::Delay;
 use parking_lot::Mutex;
 use futures::prelude::*;
 use futures::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use super::{Chain, Commit, Error, Equivocation, Message, Prevote, Precommit, PrimaryPropose, SignedMessage, HistoricalVotes};
+use super::{Chain, Commit, Error, Equivocation, Message, Prevote, Precommit, PrimaryPropose, SignedMessage};
 
 pub const GENESIS_HASH: &str = "genesis";
 const NULL_HASH: &str = "NULL";
@@ -216,7 +216,7 @@ impl crate::voter::Environment<&'static str, u32> for Environment {
 		_round: u64,
 		_state: RoundState<&'static str, u32>,
 		_base: (&'static str, u32),
-		_votes: HistoricalVotes<SignedMessage<&'static str, u32, Signature, Id>>,
+		_votes: Vec<SignedMessage<&'static str, u32, Signature, Id>>,
 	) -> Result<(), Error> {
 		Ok(())
 	}

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use crate::round::State as RoundState;
 use crate::{
 	Chain, Commit, CompactCommit, Equivocation, Message, Prevote, Precommit, PrimaryPropose,
-	SignedMessage, BlockNumberOps, validate_commit, CommitValidationResult
+	SignedMessage, BlockNumberOps, validate_commit, CommitValidationResult, HistoricalVotes,
 };
 use crate::voter_set::VoterSet;
 use past_rounds::PastRounds;
@@ -101,7 +101,7 @@ pub trait Environment<H: Eq, N: BlockNumberOps>: Chain<H, N> {
 		round: u64,
 		state: RoundState<H, N>,
 		base: (H, N),
-		votes: Vec<SignedMessage<H, N, Self::Signature, Self::Id>>,
+		votes: &HistoricalVotes<H, N>,
 	) -> Result<(), Self::Error>;
 
 	/// Called when a block should be finalized.
@@ -662,7 +662,7 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 			self.best_round.round_number(),
 			self.best_round.round_state(),
 			self.best_round.dag_base(),
-			self.best_round.votes(),
+			self.best_round.historical_votes(),
 		)?;
 
 		let old_round_number = self.best_round.round_number();
@@ -690,7 +690,7 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 			prospective_round.round_number(),
 			prospective_round.round_state(),
 			prospective_round.dag_base(),
-			prospective_round.votes(),
+			prospective_round.historical_votes(),
 		)?;
 
 		self.best_round = VotingRound::new(

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -101,7 +101,7 @@ pub trait Environment<H: Eq, N: BlockNumberOps>: Chain<H, N> {
 		round: u64,
 		state: RoundState<H, N>,
 		base: (H, N),
-		votes: &HistoricalVotes<H, N>,
+		votes: &HistoricalVotes<H, N, Self::Signature, Self::Id>,
 	) -> Result<(), Self::Error>;
 
 	/// Called when a block should be finalized.

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -36,11 +36,11 @@ use std::sync::Arc;
 use crate::round::State as RoundState;
 use crate::{
 	Chain, Commit, CompactCommit, Equivocation, Message, Prevote, Precommit, PrimaryPropose,
-	SignedMessage, BlockNumberOps, validate_commit, CommitValidationResult
+	SignedMessage, BlockNumberOps, validate_commit, CommitValidationResult, HistoricalVotes,
 };
 use crate::voter_set::VoterSet;
 use past_rounds::PastRounds;
-use voting_round::{VotingRound, State as VotingRoundState, HistoricalVotes};
+use voting_round::{VotingRound, State as VotingRoundState};
 
 mod past_rounds;
 mod voting_round;

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -40,7 +40,7 @@ use crate::{
 };
 use crate::voter_set::VoterSet;
 use past_rounds::PastRounds;
-use voting_round::{VotingRound, State as VotingRoundState};
+use voting_round::{VotingRound, State as VotingRoundState, HistoricalVotes};
 
 mod past_rounds;
 mod voting_round;
@@ -101,7 +101,7 @@ pub trait Environment<H: Eq, N: BlockNumberOps>: Chain<H, N> {
 		round: u64,
 		state: RoundState<H, N>,
 		base: (H, N),
-		votes: Vec<SignedMessage<H, N, Self::Signature, Self::Id>>,
+		votes: HistoricalVotes<SignedMessage<H, N, Self::Signature, Self::Id>>,
 	) -> Result<(), Self::Error>;
 
 	/// Called when a block should be finalized.

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use crate::round::State as RoundState;
 use crate::{
 	Chain, Commit, CompactCommit, Equivocation, Message, Prevote, Precommit, PrimaryPropose,
-	SignedMessage, BlockNumberOps, validate_commit, CommitValidationResult, HistoricalVotes,
+	SignedMessage, BlockNumberOps, validate_commit, CommitValidationResult,
 };
 use crate::voter_set::VoterSet;
 use past_rounds::PastRounds;
@@ -101,7 +101,7 @@ pub trait Environment<H: Eq, N: BlockNumberOps>: Chain<H, N> {
 		round: u64,
 		state: RoundState<H, N>,
 		base: (H, N),
-		votes: HistoricalVotes<SignedMessage<H, N, Self::Signature, Self::Id>>,
+		votes: Vec<SignedMessage<H, N, Self::Signature, Self::Id>>,
 	) -> Result<(), Self::Error>;
 
 	/// Called when a block should be finalized.

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -36,7 +36,7 @@ use std::sync::Arc;
 use crate::round::State as RoundState;
 use crate::{
 	Chain, Commit, CompactCommit, Equivocation, Message, Prevote, Precommit, PrimaryPropose,
-	SignedMessage, BlockNumberOps, validate_commit, CommitValidationResult,
+	SignedMessage, BlockNumberOps, validate_commit, CommitValidationResult
 };
 use crate::voter_set::VoterSet;
 use past_rounds::PastRounds;

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -370,6 +370,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 					if let Some(prevote) = self.construct_prevote(last_round_state)? {
 						debug!(target: "afg", "Casting prevote for round {}", self.votes.number());
 						self.env.prevoted(self.round_number(), prevote.clone())?;
+						self.votes.set_prevote_idx();
 						self.outgoing.push(Message::Prevote(prevote));
 					}
 				}
@@ -421,6 +422,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 					if self.voting.is_active() {
 						debug!(target: "afg", "Casting precommit for round {}", self.votes.number());
 						let precommit = self.construct_precommit();
+						self.votes.set_precommit_idx();
 						self.env.precommitted(self.round_number(), precommit.clone())?;
 						self.outgoing.push(Message::Precommit(precommit));
 					}

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -277,8 +277,8 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		prevotes.chain(precommits).collect()
 	}
 
-	/// Return all votes for the round (prevotes and precommits) 
-	/// sorted by importing order and indicating at which indices we voted.
+	/// Return all votes for the round (prevotes and precommits), 
+	/// sorted by imported order and indicating the indices where we voted.
 	pub(super) fn historical_votes(&self) -> &HistoricalVotes<H, N> {
 		self.votes.historical_votes()
 	}

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -256,30 +256,9 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		self.best_finalized.as_ref()
 	}
 
-	/// Return all imported votes for the round (prevotes and precommits) unordered.
-	pub(super) fn votes(&self) -> Vec<SignedMessage<H, N, E::Signature, E::Id>> {
-		let prevotes = self.votes.prevotes().into_iter().map(|(id, prevote, signature)| {
-			SignedMessage {
-				id,
-				signature,
-				message: Message::Prevote(prevote),
-			}
-		});
-
-		let precommits = self.votes.precommits().into_iter().map(|(id, precommit, signature)| {
-			SignedMessage {
-				id,
-				signature,
-				message: Message::Precommit(precommit),
-			}
-		});
-
-		prevotes.chain(precommits).collect()
-	}
-
 	/// Return all votes for the round (prevotes and precommits), 
 	/// sorted by imported order and indicating the indices where we voted.
-	pub(super) fn historical_votes(&self) -> &HistoricalVotes<H, N> {
+	pub(super) fn historical_votes(&self) -> &HistoricalVotes<H, N, E::Signature, E::Id> {
 		self.votes.historical_votes()
 	}
 

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -277,8 +277,8 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		prevotes.chain(precommits).collect()
 	}
 
-	/// Return all imported votes for the round (prevotes and precommits) ordered
-	/// and indicating at which indices we voted.
+	/// Return all votes for the round (prevotes and precommits) 
+	/// sorted by importing order and indicating at which indices we voted.
 	pub(super) fn historical_votes(&self) -> &HistoricalVotes<H, N> {
 		self.votes.historical_votes()
 	}

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -24,6 +24,7 @@ use crate::round::{Round, State as RoundState};
 use crate::{
 	Commit, Message, Prevote, Precommit, PrimaryPropose, SignedMessage,
 	SignedPrecommit, BlockNumberOps, validate_commit, ImportResult,
+	HistoricalVotes,
 };
 use crate::voter_set::VoterSet;
 use super::{Environment, Buffered};
@@ -93,12 +94,6 @@ impl Voting {
 			_ => false,
 		}
 	}
-}
-
-pub struct HistoricalVotes<M> {
-	seen: Vec<M>,
-	prevote_idx: usize,
-	precommit_idx: usize,
 }
 
 impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where


### PR DESCRIPTION
Starting #10 

This PR adds the `HistoricalVotes` struct, for saving votes in received order and indicating the moment of prevoting and precommiting.