### PR TITLE
Add test helpers to construct opaque types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finality-grandpa"
-version = "0.8.0"
+version = "0.8.1"
 description = "PBFT-based finality gadget for blockchains"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ tokio = "0.1.8"
 default = ["std"]
 std = ["parity-codec/std", "hashmap_core/disable"]
 derive-codec = ["parity-codec"]
+test-helpers = []

--- a/src/round.rs
+++ b/src/round.rs
@@ -699,7 +699,10 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		self.precommit.votes()
 	}
 
-	/// Return all votes (prevotes and precommits) by importing order.
+	/// Return all votes for the round (prevotes and precommits), sorted by
+	/// imported order and indicating the indices where we voted. At most two
+	/// prevotes and two precommits per voter are present, further equivocations
+	/// are not stored (as they are redundant).
 	pub fn historical_votes(&self) -> &HistoricalVotes<H, N, Signature, Id> {
 		&self.historical_votes
 	}

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -134,6 +134,19 @@ pub enum CommitProcessingOutcome {
 	Bad(BadCommit),
 }
 
+#[cfg(any(test, feature = "test-helpers"))]
+impl CommitProcessingOutcome {
+	/// Returns a `Good` instance of commit processing outcome's opaque type. Useful for testing.
+	pub fn good() -> CommitProcessingOutcome {
+		CommitProcessingOutcome::Good(GoodCommit::new())
+	}
+
+	/// Returns a `Bad` instance of commit processing outcome's opaque type. Useful for testing.
+	pub fn bad() -> CommitProcessingOutcome {
+		CommitProcessingOutcome::Bad(CommitValidationResult::<(), ()>::default().into())
+	}
+}
+
 /// The result of processing for a good commit.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GoodCommit {
@@ -201,6 +214,19 @@ pub enum CatchUpProcessingOutcome {
 	/// The catch up wasn't processed because it is useless, e.g. it is for a
 	/// round lower than we're currently in.
 	Useless,
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl CatchUpProcessingOutcome {
+	/// Returns a `Bad` instance of catch up processing outcome's opaque type. Useful for testing.
+	pub fn bad() -> CatchUpProcessingOutcome {
+		CatchUpProcessingOutcome::Bad(BadCatchUp::new())
+	}
+
+	/// Returns a `Good` instance of catch up processing outcome's opaque type. Useful for testing.
+	pub fn good() -> CatchUpProcessingOutcome {
+		CatchUpProcessingOutcome::Good(GoodCatchUp::new())
+	}
 }
 
 /// The result of processing for a good catch up.

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -280,8 +280,10 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		self.best_finalized.as_ref()
 	}
 
-	/// Return all votes for the round (prevotes and precommits),
-	/// sorted by imported order and indicating the indices where we voted.
+	/// Return all votes for the round (prevotes and precommits), sorted by
+	/// imported order and indicating the indices where we voted. At most two
+	/// prevotes and two precommits per voter are present, further equivocations
+	/// are not stored (as they are redundant).
 	pub(super) fn historical_votes(&self) -> &HistoricalVotes<H, N, E::Signature, E::Id> {
 		self.votes.historical_votes()
 	}


### PR DESCRIPTION
The `CommitProcessingOutcome` and `CatchUpProcessingOutcome` types are opaque and it's not possible to construct them from outside this crate which is useful for testing. Used in https://github.com/paritytech/substrate/pull/2801.