### PR TITLE
Wait for previous round estimate to be finalized

### DIFF
--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -215,13 +215,13 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 				// either it was already finalized in the previous round
 				let finalized_in_last_round = self.env.is_equal_or_descendent_of(
 					last_round_estimate.clone(),
-					last_round_finalized.clone(),
+					last_round_finalized,
 				);
 
 				// or it must be finalized in the current round
 				let finalized_in_current_round = self.finalized().map(|(current_round_finalized, _)| {
 					self.env.is_equal_or_descendent_of(
-						last_round_estimate.clone(),
+						last_round_estimate,
 						current_round_finalized.clone(),
 					)
 				}).unwrap_or(false);

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -237,7 +237,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 			return Ok(Async::NotReady);
 		}
 
-		// both conditions verified, we can complete this round
+		// both exit conditions verified, we can complete this round
 		Ok(Async::Ready(()))
 	}
 

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -208,23 +208,18 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		// make sure that the previous round estimate has been finalized
 		let last_round_estimate_finalized = match last_round_state {
 			Some(RoundState {
-				estimate: Some((last_round_estimate, _)),
-				finalized: Some((last_round_finalized, _)),
+				estimate: Some((_, last_round_estimate)),
+				finalized: Some((_, last_round_finalized)),
 				..
 			}) => {
 				// either it was already finalized in the previous round
-				let finalized_in_last_round = self.env.is_equal_or_descendent_of(
-					last_round_estimate.clone(),
-					last_round_finalized,
-				);
+				let finalized_in_last_round = last_round_estimate <= last_round_finalized;
 
 				// or it must be finalized in the current round
-				let finalized_in_current_round = self.finalized().map(|(current_round_finalized, _)| {
-					self.env.is_equal_or_descendent_of(
-						last_round_estimate,
-						current_round_finalized.clone(),
-					)
-				}).unwrap_or(false);
+				let finalized_in_current_round = self.finalized().map_or(
+					false,
+					|(_, current_round_finalized)| last_round_estimate <= *current_round_finalized,
+				);
 
 				finalized_in_last_round || finalized_in_current_round
 			},


### PR DESCRIPTION
Before starting round R we guarantee that the estimate of round R-2 has been finalized.