### PR TITLE
Fix grandpa no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ repository = "https://github.com/paritytech/finality-grandpa"
 edition = "2018"
 
 [dependencies]
-parking_lot = "0.9"
 futures = "0.1"
 log = "0.4"
+parking_lot = { version = "0.9", optional = true }
 parity-codec = { version = "4.1", optional = true, default-features = false, features = ["derive"] }
 num = { package = "num-traits", version = "0.2", default-features = false }
 hashmap_core = { version = "0.1.10", default-features = false }
@@ -22,6 +22,6 @@ tokio = "0.1.8"
 
 [features]
 default = ["std"]
-std = ["parity-codec/std", "hashmap_core/disable", "num/std"]
+std = ["parity-codec/std", "hashmap_core/disable", "num/std", "parking_lot"]
 derive-codec = ["parity-codec"]
 test-helpers = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,9 +35,14 @@ extern crate core as std;
 extern crate alloc;
 
 pub mod bitfield;
+
 pub mod round;
+use round::ImportResult;
+
 pub mod vote_graph;
+
 pub mod voter_set;
+use crate::voter_set::VoterSet;
 
 #[cfg(feature = "std")]
 pub mod voter;
@@ -48,12 +53,12 @@ mod bridge_state;
 #[cfg(test)]
 mod testing;
 
-use collections::Vec;
 use std::fmt;
-use crate::voter_set::VoterSet;
-use round::ImportResult;
+
 #[cfg(feature = "derive-codec")]
 use parity_codec::{Encode, Decode};
+
+use collections::Vec;
 
 #[cfg(not(feature = "std"))]
 mod collections {

--- a/src/round.rs
+++ b/src/round.rs
@@ -368,7 +368,7 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		// update prevote-GHOST
 		let threshold = self.threshold();
 		if self.prevote.current_weight >= threshold {
-			let equivocators = self.bitfield_context.equivocators().read();
+			let equivocators = self.bitfield_context.equivocators();
 
 			self.prevote_ghost = self.graph.find_ghost(
 				self.prevote_ghost.take(),
@@ -471,7 +471,7 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		// update precommit-GHOST
 		let threshold = self.threshold();
 		if self.precommit.current_weight >= threshold {
-			let equivocators = self.bitfield_context.equivocators().read();
+			let equivocators = self.bitfield_context.equivocators();
 
 			self.precommit_ghost = self.graph.find_ghost(
 				self.precommit_ghost.take(),
@@ -551,8 +551,7 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		if self.prevote.current_weight < threshold { return }
 
 		let remaining_commit_votes = self.total_weight - self.precommit.current_weight;
-		let equivocators = self.bitfield_context.equivocators().read();
-		let equivocators = &*equivocators;
+		let equivocators = &self.bitfield_context.equivocators();
 
 		let voters = &self.voters;
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -21,7 +21,7 @@ use std::ops::AddAssign;
 use parity_codec::{Encode, Decode};
 
 use crate::collections::{hash_map::{HashMap, Entry}, Vec};
-use crate::bitfield::{Shared as BitfieldContext, Bitfield};
+use crate::bitfield::{Context as BitfieldContext, Bitfield};
 use crate::vote_graph::VoteGraph;
 use crate::voter_set::VoterSet;
 


### PR DESCRIPTION
This add a couple of guards to allow importing structs (`Message`, `Equivocation`) into no-std.

It may be enough for my use case in Substrate (at least for equivocations).

But the plan is to make follow up PRs implementing no-std for each guarded module (and removing the corresponding guard).