### PR TITLE
bump version to v0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finality-grandpa"
-version = "0.9.0"
+version = "0.9.1"
 description = "PBFT-based finality gadget for blockchains"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"

--- a/src/round.rs
+++ b/src/round.rs
@@ -299,6 +299,7 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		self.round_number
 	}
 
+	#[allow(unused)]
 	/// Import a prevote. Returns an equivocation proof, if the vote is an equivocation,
 	/// and a bool indicating if the vote is duplicated (see `ImportResult`).
 	///


### PR DESCRIPTION
Need to release latest master since it includes some fixes for building under no-std environment (needed for https://github.com/paritytech/substrate/pull/3868).

The only changes included from v0.9.0 are:
- https://github.com/paritytech/finality-grandpa/pull/84
- https://github.com/paritytech/finality-grandpa/pull/86

Neither of them seems breaking.