### PR TITLE
do not compute estimate until round could possibly be completable

### DIFF
--- a/src/round.rs
+++ b/src/round.rs
@@ -798,7 +798,26 @@ mod tests {
 		).unwrap();
 
 		assert_eq!(round.prevote_ghost, Some(("E", 6)));
+		assert_eq!(round.estimate(), None);
+		assert!(!round.completable());
+
+		round.import_precommit(
+			&chain,
+			Precommit::new("E", 6),
+			"Alice",
+			Signature("Alice"),
+		).unwrap();
+
+		round.import_precommit(
+			&chain,
+			Precommit::new("E", 6),
+			"Bob",
+			Signature("Bob"),
+		).unwrap();
+
+		assert_eq!(round.prevote_ghost, Some(("E", 6)));
 		assert_eq!(round.estimate(), Some(&("E", 6)));
+		assert!(round.completable());
 	}
 
 	#[test]

--- a/src/round.rs
+++ b/src/round.rs
@@ -640,6 +640,9 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 				possible_to_precommit,
 			);
 		} else {
+			// although technically the estimate would be equal to the
+			// prevote-ghost here, having an estimate is not a useful notion
+			// until we have threshold precommit-weight.
 			return;
 		}
 
@@ -784,7 +787,7 @@ mod tests {
 		).unwrap();
 
 		assert_eq!(round.prevote_ghost, Some(("E", 6)));
-		assert_eq!(round.estimate(), Some(&("E", 6)));
+		assert_eq!(round.estimate(), None);
 		assert!(!round.completable());
 
 		round.import_prevote(

--- a/src/round.rs
+++ b/src/round.rs
@@ -640,7 +640,6 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 				possible_to_precommit,
 			);
 		} else {
-			self.estimate = Some((g_hash, g_num));
 			return;
 		}
 


### PR DESCRIPTION
(updated after Roman's comment below)

We do not compute the estimate until the round could possibly be completable, which is when no new leaf nodes can get a threshold amount of precommits. Until that point, the estimate of what has been finalized is probably not useful, although technically equal to the `prevote_ghost`. This is a relaxation of the pre-existing rule.