### PR TITLE
VoterSet and Bitfield Refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,12 @@ parking_lot = { version = "0.9", optional = true }
 parity-scale-codec = { version = "1.0.3", optional = true, default-features = false, features = ["derive"] }
 num = { package = "num-traits", version = "0.2", default-features = false }
 rand = {version = "0.6.0", optional = true }
+hashbrown = { version = "0.6" }
+either = { version = "1.5.3", default-features = false }
 
 [dev-dependencies]
-rand = "0.6.0"
+rand = "0.7.0"
+quickcheck = "0.9"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ parking_lot = { version = "0.9", optional = true }
 parity-scale-codec = { version = "1.0.3", optional = true, default-features = false, features = ["derive"] }
 num = { package = "num-traits", version = "0.2", default-features = false }
 rand = {version = "0.6.0", optional = true }
-hashbrown = { version = "0.6" }
 either = { version = "1.5.3", default-features = false }
 
 [dev-dependencies]

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -12,387 +12,268 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Bitfields and tools for handling equivocations.
-//!
-//! This is primarily a bitfield for tracking equivocating voters.
-//! It is necessary because there is a need to track vote-weight of equivocation
-//! on the vote-graph but to avoid double-counting.
-//!
-//! We count equivocating voters as voting for everything. This makes any
-//! further equivocations redundant with the first.
-//!
-//! Bitfields are either blank or live, with two bits per equivocator.
-//! The first is for equivocations in prevote messages and the second
-//! for those in precommits.
-//!
-//! Bitfields on regular vote-nodes will tend to be live, but the equivocating
-//! bitfield will be mostly empty.
+//! Dynamically sized, write-once, lazily allocating bitfields,
+//! e.g. for compact accumulation of votes cast on a block while
+//! retaining information on the type of vote and identity of the
+//! voter within a voter set.
 
-#[cfg(feature = "std")]
-use parking_lot::RwLock;
+use crate::std::{iter, cmp::Ordering, vec::Vec, ops::BitOr};
+use either::Either;
 
-#[cfg(feature = "std")]
-use std::sync::Arc;
-
-use crate::std::{self, vec::Vec};
-use crate::voter_set::VoterInfo;
-
-/// Errors that can occur when using the equivocation weighting tools.
-#[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(any(feature = "std", test), derive(
-Debug))]
-pub enum Error {
-	/// Attempted to index bitfield past its length.
-	IndexOutOfBounds(usize, usize),
-	/// Mismatch in bitfield length when merging bitfields.
-	LengthMismatch(usize, usize),
-}
-
-#[cfg(feature = "std")]
-impl std::fmt::Display for Error {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		match *self {
-			Error::IndexOutOfBounds(ref idx, ref n)
-				=> write!(f, "Attempted to set voter {}. Maximum specified was {}", idx, n),
-			Error::LengthMismatch(ref idx1, ref idx2)
-				=> write!(f, "Attempted to merge bitfields with different lengths: {} vs {}", idx1, idx2),
-		}
-	}
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
-
-/// Bitfield for tracking voters who have equivocated.
+/// A dynamically sized, write-once (per bit), lazily allocating bitfield.
 #[derive(Eq, PartialEq, Clone)]
-#[cfg_attr(any(feature = "std", test), derive(
-Debug))]
-pub enum Bitfield {
-	/// Blank bitfield,
-	Blank,
-	/// Live bitfield,
-	Live(LiveBitfield),
-}
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct Bitfield { bits: Vec<u64> }
 
 impl Default for Bitfield {
 	fn default() -> Self {
-		Bitfield::Blank
+		Bitfield { bits: Vec::new() }
+	}
+}
+
+impl From<Vec<u64>> for Bitfield {
+	fn from(bits: Vec<u64>) -> Bitfield {
+		Bitfield { bits }
 	}
 }
 
 impl Bitfield {
-	/// Combine two bitfields. Fails if they have conflicting shared data
-	/// (i.e. they come from different contexts).
-	pub fn merge(&self, other: &Self) -> Result<Self, Error> {
-		match (self, other) {
-			(&Bitfield::Blank, &Bitfield::Blank) => Ok(Bitfield::Blank),
-			(&Bitfield::Live(ref live), &Bitfield::Blank) | (&Bitfield::Blank, &Bitfield::Live(ref live))
-				=> Ok(Bitfield::Live(live.clone())),
-			(&Bitfield::Live(ref a), &Bitfield::Live(ref b)) => {
-				if a.bits.len() == b.bits.len() {
-					let bits = a.bits.iter().zip(&b.bits).map(|(a, b)| a | b).collect();
-					Ok(Bitfield::Live(LiveBitfield { bits }))
-				} else {
-					// we can't merge two bitfields with different lengths.
-					Err(Error::LengthMismatch(a.bits.len(), b.bits.len()))
-				}
-			}
-		}
+	/// Create a new empty bitfield.
+	///
+	/// Does not allocate.
+	pub fn new() -> Bitfield {
+		Bitfield { bits: Vec::new() }
 	}
 
-	/// Find overlap weight (prevote, precommit) between this bitfield and another.
-	pub fn overlap(&self, other: &Self) -> Result<Self, Error> {
-		match (self, other) {
-			(&Bitfield::Live(ref a), &Bitfield::Live(ref b)) => {
-				if a.bits.len() == b.bits.len() {
-					Ok(Bitfield::Live(LiveBitfield {
-						bits: a.bits.iter().zip(&b.bits).map(|(a, b)| a & b).collect(),
-					}))
-				} else {
-					// we can't find overlap of two bitfields with different lengths.
-					Err(Error::LengthMismatch(a.bits.len(), b.bits.len()))
-				}
-			}
-			_ => Ok(Bitfield::Blank)
-		}
+	/// Whether the bitfield is blank / empty.
+	pub fn is_blank(&self) -> bool {
+		self.bits.is_empty()
 	}
 
-	/// Find total equivocating weight (prevote, precommit).
-	/// Provide a function for looking up voter weight.
-	pub fn total_weight<F: Fn(usize) -> u64>(&self, lookup: F) -> (u64, u64) {
-		match *self {
-			Bitfield::Blank => (0, 0),
-			Bitfield::Live(ref live) => total_weight(live.bits.iter().cloned(), lookup),
+	/// Merge another bitfield into this bitfield.
+	///
+	/// As a result, this bitfield has all bits set that are set in either bitfield.
+	///
+	/// This function only allocates if this bitfield is shorter than the other
+	/// bitfield, in which case it is resized accordingly to accomodate for all
+	/// bits of the other bitfield.
+	pub fn merge(&mut self, other: &Self) -> &mut Self {
+		if self.bits.len() < other.bits.len() {
+		    let new_len = other.bits.len();
+		    self.bits.resize(new_len, 0);
 		}
+
+		for (i, word) in other.bits.iter().enumerate() {
+			self.bits[i] |= word;
+		}
+
+		self
 	}
 
-	/// Set a bit in the bitfield.
-	fn set_bit(&mut self, bit: usize, n_voters: usize) -> Result<(), Error> {
-		let mut live = match std::mem::replace(self, Bitfield::Blank) {
-			Bitfield::Blank => LiveBitfield::with_voters(n_voters),
-			Bitfield::Live(live) => live,
-		};
+	/// Set a bit in the bitfield at the specified position.
+	///
+	/// If the bitfield is not large enough to accomodate for a bit set
+	/// at the specified position, it is resized accordingly.
+	pub fn set_bit(&mut self, position: usize) -> &mut Self {
+		let word_off = position / 64;
+		let bit_off = position % 64;
 
-		live.set_bit(bit, n_voters)?;
-		*self = Bitfield::Live(live);
-		Ok(())
+		if word_off >= self.bits.len() {
+		    let new_len = word_off + 1;
+		    self.bits.resize(new_len, 0);
+		}
+
+		self.bits[word_off] |= 1 << (63 - bit_off);
+		self
+	}
+
+	/// Test if the bit at the specified position is set.
+	#[cfg(test)]
+	pub fn test_bit(&self, position: usize) -> bool {
+		let word_off = position / 64;
+
+		if word_off >= self.bits.len() {
+			return false
+		}
+
+		test_bit(self.bits[word_off], position % 64)
+	}
+
+	/// Get an iterator over all bits that are set (i.e. 1) at even bit positions.
+	pub fn iter1s_even(&self) -> impl Iterator<Item = Bit1> + '_ {
+		self.iter1s(0, 1)
+	}
+
+	/// Get an iterator over all bits that are set (i.e. 1) at odd bit positions.
+	pub fn iter1s_odd(&self) -> impl Iterator<Item = Bit1> + '_ {
+		self.iter1s(1, 1)
+	}
+
+	/// Get an iterator over all bits that are set (i.e. 1) at even bit positions
+	/// when merging this bitfield with another bitfield, without modifying
+	/// either bitfield.
+	pub fn iter1s_merged_even<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = Bit1> + 'a {
+		self.iter1s_merged(other, 0, 1)
+	}
+
+	/// Get an iterator over all bits that are set (i.e. 1) at odd bit positions
+	/// when merging this bitfield with another bitfield, without modifying
+	/// either bitfield.
+	pub fn iter1s_merged_odd<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = Bit1> + 'a {
+		self.iter1s_merged(other, 1, 1)
+	}
+
+	/// Get an iterator over all bits that are set (i.e. 1) in the bitfield,
+	/// starting at bit position `start` and moving in steps of size `2^step`
+	/// per word.
+	fn iter1s(&self, start: usize, step: usize) -> impl Iterator<Item = Bit1> + '_ {
+		iter1s(self.bits.iter().cloned(), start, step)
+	}
+
+	/// Get an iterator over all bits that are set (i.e. 1) when merging
+	/// this bitfield with another bitfield, without modifying either
+	/// bitfield.
+	fn iter1s_merged<'a>(&'a self, other: &'a Self, start: usize, step: usize) -> impl Iterator<Item = Bit1> + 'a {
+		match self.bits.len().cmp(&other.bits.len()) {
+			Ordering::Equal =>
+				Either::Left(iter1s(
+					self.bits.iter()
+						.zip(&other.bits)
+						.map(|(a, b)| a | b), start, step)),
+			Ordering::Less =>
+				Either::Right(Either::Left(iter1s(
+					self.bits.iter()
+						.chain(iter::repeat(&0))
+						.zip(&other.bits)
+						.map(|(a, b)| a | b), start, step))),
+			Ordering::Greater =>
+				Either::Right(Either::Right(iter1s(
+					self.bits.iter()
+						.zip(other.bits.iter().chain(iter::repeat(&0)))
+						.map(|(a, b)| a | b), start, step)))
+		}
 	}
 }
 
-/// Live bitfield instance.
-#[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(any(feature = "std", test), derive(
-Debug))]
-pub struct LiveBitfield {
-	bits: Vec<u64>,
-}
-
-impl LiveBitfield {
-	fn with_voters(n_voters: usize) -> Self {
-		let n_bits = n_voters * 2;
-		let n_words = (n_bits + 63) / 64;
-
-		LiveBitfield { bits: vec![0; n_words] }
-	}
-
-	fn set_bit(&mut self, bit_idx: usize, n_voters: usize) -> Result<(), Error> {
-		let word_off = bit_idx / 64;
-		let bit_off = bit_idx % 64;
-
-		// If this isn't `Some`, something has gone really wrong.
-		if let Some(word) = self.bits.get_mut(word_off) {
-			// set bit starting from left.
-			*word |= 1 << (63 - bit_off);
-			Ok(())
-		} else {
-			Err(Error::IndexOutOfBounds(bit_idx / 2, n_voters))
-		}
-	}
-}
-
-// find total weight of the given iterable of bits. assumes that there are enough
-// voters in the given context to correspond to all bits.
-fn total_weight<Iter, Lookup>(iterable: Iter, lookup: Lookup) -> (u64, u64) where
-	Iter: IntoIterator<Item=u64>,
-	Lookup: Fn(usize) -> u64,
+/// Turn an iterator over u64 words into an iterator over bits that
+/// are set (i.e. `1`) in these words, starting at bit position `start`
+/// and moving in steps of size `2^step` per word.
+fn iter1s<'a, I>(iter: I, start: usize, step: usize) -> impl Iterator<Item = Bit1> + 'a
+where
+	I: Iterator<Item = u64> + 'a
 {
-	struct State {
-		val_idx: usize,
-		prevote: u64,
-		precommit: u64,
-	};
-
-	let state = State {
-		val_idx: 0,
-		prevote: 0,
-		precommit: 0,
-	};
-
-	let state = iterable.into_iter().fold(state, |mut state, mut word| {
-		for i in 0..32 {
-			if word == 0 { break }
-
-			// prevote bit is set
-			if word & (1 << 63) == (1 << 63) {
-				state.prevote += lookup(state.val_idx + i);
+	debug_assert!(start < 64 && step < 7);
+	let steps = (64 >> step) - (start >> step);
+	iter.enumerate().flat_map(move |(i, word)| {
+		let n = if word == 0 { 0 } else { steps };
+		(0 .. n).filter_map(move |j| {
+			let bit_pos = start + (j << step);
+			if test_bit(word, bit_pos) {
+				Some(Bit1 { position: i * 64 + bit_pos })
+			} else {
+				None
 			}
-
-			// precommit bit is set
-			if word & (1 << 62) == (1 << 62) {
-				state.precommit += lookup(state.val_idx + i);
-			}
-
-			word <<= 2;
-		}
-
-		state.val_idx += 32;
-		state
-	});
-
-	(state.prevote, state.precommit)
+		})
+	})
 }
 
-/// Context data for bitfields, shared among all live bitfield instances.
-/// (only usable under std environment.)
-#[cfg(feature = "std")]
-#[derive(Debug)]
-pub struct Context {
-	n_voters: usize,
-	equivocators: Arc<RwLock<Bitfield>>,
+fn test_bit(word: u64, position: usize) -> bool {
+	let mask = 1 << (63 - position);
+	word & mask == mask
 }
 
-/// Context data for bitfields, shared among all live bitfield instances.
-/// (usable under no-std environment, where it is not expected that this data
-/// will be shared across different threads.)
-#[cfg(not(feature = "std"))]
-pub struct Context {
-	n_voters: usize,
-	equivocators: Bitfield,
+impl BitOr<&Bitfield> for Bitfield {
+    type Output = Bitfield;
+
+    fn bitor(mut self, rhs: &Bitfield) -> Self::Output {
+        self.merge(&rhs);
+		self
+    }
 }
 
-impl Clone for Context {
-	fn clone(&self) -> Self {
-		Context {
-			n_voters: self.n_voters,
-			equivocators: self.equivocators.clone(),
-		}
-	}
-}
-
-#[cfg(feature = "std")]
-impl Context {
-	pub fn new(n_voters: usize) -> Self {
-		Context {
-			n_voters,
-			equivocators: Arc::new(RwLock::new(Bitfield::Blank)),
-		}
-	}
-
-	/// Get a reference to the equivocators bitfield.
-	pub fn equivocators(&self) -> parking_lot::RwLockReadGuard<Bitfield> {
-		self.equivocators.read()
-	}
-
-	/// Get a mutable reference to the equivocators bitfield.
-	pub fn equivocators_mut(&mut self) -> parking_lot::RwLockWriteGuard<Bitfield> {
-		self.equivocators.write()
-	}
-}
-
-#[cfg(not(feature = "std"))]
-impl Context {
-	/// Create new shared equivocation detection data. Provide the number of voters.
-	pub fn new(n_voters: usize) -> Self {
-		Context {
-			n_voters,
-			equivocators: Bitfield::Blank,
-		}
-	}
-
-	/// Get a reference to the equivocators bitfield.
-	pub fn equivocators(&self) -> &Bitfield {
-		&self.equivocators
-	}
-
-	/// Get a mutable reference to the equivocators bitfield.
-	pub fn equivocators_mut(&mut self) -> &mut Bitfield {
-		&mut self.equivocators
-	}
-}
-
-impl Context {
-	/// Construct a new bitfield for a specific voter prevoting.
-	pub fn prevote_bitfield(&self, info: &VoterInfo) -> Result<Bitfield, Error> {
-		let mut bitfield = LiveBitfield::with_voters(self.n_voters);
-		bitfield.set_bit(info.canon_idx() * 2, self.n_voters)?;
-
-		Ok(Bitfield::Live(bitfield))
-	}
-
-	/// Construct a new bitfield for a specific voter prevoting.
-	pub fn precommit_bitfield(&self, info: &VoterInfo) -> Result<Bitfield, Error> {
-		let mut bitfield = LiveBitfield::with_voters(self.n_voters);
-		bitfield.set_bit(info.canon_idx() * 2 + 1, self.n_voters)?;
-
-		Ok(Bitfield::Live(bitfield))
-	}
-
-	/// Note a voter's equivocation in prevote.
-	pub fn equivocated_prevote(&mut self, info: &VoterInfo) -> Result<(), Error> {
-		let n_voters = self.n_voters;
-		self.equivocators_mut().set_bit(info.canon_idx() * 2, n_voters)?;
-
-		Ok(())
-	}
-
-	/// Note a voter's equivocation in precommit.
-	pub fn equivocated_precommit(&mut self, info: &VoterInfo) -> Result<(), Error> {
-		let n_voters = self.n_voters;
-		self.equivocators_mut().set_bit(info.canon_idx() * 2 + 1, n_voters)?;
-
-		Ok(())
-	}
+/// A bit that is set (i.e. 1) in a `Bitfield`.
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+pub struct Bit1 {
+	/// The position of the bit in the bitfield.
+	pub position: usize
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::VoterSet;
+	use quickcheck::*;
+	use rand::Rng;
+	use crate::std::iter;
 
-	fn to_prevote(id: usize) -> usize {
-		id * 2
-	}
-
-	fn to_precommit(id: usize) -> usize {
-		id * 2 + 1
-	}
-
-	#[test]
-	fn merge_live() {
-		let mut a = Bitfield::Live(LiveBitfield::with_voters(10));
-		let mut b = Bitfield::Live(LiveBitfield::with_voters(10));
-
-		let v: VoterSet<usize> = [
-			(1, 5),
-			(4, 1),
-			(3, 9),
-			(5, 7),
-			(9, 9),
-			(2, 7),
-		].iter().cloned().collect();
-
-		a.set_bit(to_prevote(v.info(&1).unwrap().canon_idx()), 10).unwrap(); // prevote 1
-		a.set_bit(to_precommit(v.info(&2).unwrap().canon_idx()), 10).unwrap(); // precommit 2
-
-		b.set_bit(to_prevote(v.info(&3).unwrap().canon_idx()), 10).unwrap(); // prevote 3
-		b.set_bit(to_precommit(v.info(&3).unwrap().canon_idx()), 10).unwrap(); // precommit 3
-
-		let c = a.merge(&b).unwrap();
-		assert_eq!(c.total_weight(|i| v.weight_by_index(i).unwrap()), (14, 16));
+	impl Arbitrary for Bitfield {
+		fn arbitrary<G: Gen>(g: &mut G) -> Bitfield {
+			let n = g.gen_range(0, g.size());
+			let b = iter::from_fn(|| Some(g.next_u64())).take(n).collect::<Vec<_>>();
+			Bitfield::from(b)
+		}
 	}
 
 	#[test]
-	fn set_first_and_last_bits() {
-		let v: VoterSet<usize> = (0..32).map(|i| (i, (i + 1) as u64)).collect();
+	fn set_bit() {
+		fn prop(mut a: Bitfield, idx: usize) -> bool {
+			a.set_bit(idx).test_bit(idx)
+		}
 
-		let mut live_bitfield = Bitfield::Live(LiveBitfield::with_voters(32));
-
-		live_bitfield.set_bit(0, 32).unwrap();
-		live_bitfield.set_bit(63, 32).unwrap();
-
-		assert_eq!(live_bitfield.total_weight(|i| v.weight_by_index(i).unwrap()), (1, 32));
+		quickcheck(prop as fn(_,_) -> _)
 	}
 
 	#[test]
-	fn weight_overlap() {
-		let mut a = Bitfield::Live(LiveBitfield::with_voters(10));
-		let mut b = Bitfield::Live(LiveBitfield::with_voters(10));
+	fn bitor() {
+		fn prop(a: Bitfield, b: Bitfield) -> bool {
+			let c = a.clone() | &b;
+			let mut c_bits = c.iter1s(0, 1);
+			c_bits.all(|bit| a.test_bit(bit.position) || b.test_bit(bit.position))
+		}
 
-		let v: VoterSet<usize> = [
-			(1, 5),
-			(4, 1),
-			(3, 9),
-			(5, 7),
-			(9, 9),
-			(2, 7),
-		].iter().cloned().collect();
+		quickcheck(prop as fn(_,_) -> _)
+	}
 
-		a.set_bit(to_prevote(v.info(&1).unwrap().canon_idx()), 10).unwrap(); // prevote 1
-		a.set_bit(to_precommit(v.info(&2).unwrap().canon_idx()), 10).unwrap(); // precommit 2
-		a.set_bit(to_prevote(v.info(&3).unwrap().canon_idx()), 10).unwrap(); // prevote 3
+	#[test]
+	fn bitor_commutative() {
+		fn prop(a: Bitfield, b: Bitfield) -> bool {
+			a.clone() | &b == b | &a
+		}
 
-		b.set_bit(to_prevote(v.info(&1).unwrap().canon_idx()), 10).unwrap(); // prevote 1
-		b.set_bit(to_precommit(v.info(&2).unwrap().canon_idx()), 10).unwrap(); // precommit 2
-		b.set_bit(to_precommit(v.info(&3).unwrap().canon_idx()), 10).unwrap(); // precommit 3
+		quickcheck(prop as fn(_,_) -> _)
+	}
 
-		assert_eq!(a.total_weight(|i| v.weight_by_index(i).unwrap()), (14, 7));
-		assert_eq!(b.total_weight(|i| v.weight_by_index(i).unwrap()), (5, 16));
+	#[test]
+	fn bitor_associative() {
+		fn prop(a: Bitfield, b: Bitfield, c: Bitfield) -> bool {
+			(a.clone() | &b) | &c == a | &(b | &c)
+		}
 
-		let mut c = Bitfield::Live(LiveBitfield::with_voters(10));
+		quickcheck(prop as fn(_,_,_) -> _)
+	}
 
-		c.set_bit(to_prevote(v.info(&1).unwrap().canon_idx()), 10).unwrap(); // prevote 1
-		c.set_bit(to_precommit(v.info(&2).unwrap().canon_idx()), 10).unwrap(); // precommit 2
+	#[test]
+	fn iter1s() {
+		fn prop(a: Bitfield) {
+			let mut b = Bitfield::new();
+			for Bit1 { position } in a.iter1s(0, 0) {
+				b.set_bit(position);
+			}
+			assert_eq!(a, b);
+		}
 
-		assert_eq!(a.overlap(&b).unwrap(), c);
+		quickcheck(prop as fn(_))
+	}
+
+	#[test]
+	fn iter1s_merged() {
+		fn prop(mut a: Bitfield, b: Bitfield) {
+			let mut c = Bitfield::new();
+			for bit1 in a.iter1s_merged(&b, 0, 0) {
+				c.set_bit(bit1.position);
+			}
+			assert_eq!(&c, a.merge(&b))
+		}
+
+		quickcheck(prop as fn(_,_))
 	}
 }

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -132,7 +132,8 @@ impl Bitfield {
 
 	/// Get an iterator over all bits that are set (i.e. 1) when merging
 	/// this bitfield with another bitfield, without modifying either
-	/// bitfield.
+	/// bitfield, starting at bit position `start` and moving in steps
+	/// of size `2^step` per word.
 	fn iter1s_merged<'a>(&'a self, other: &'a Self, start: usize, step: usize) -> impl Iterator<Item = Bit1> + 'a {
 		match self.bits.len().cmp(&other.bits.len()) {
 			Ordering::Equal =>

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -21,8 +21,7 @@ use crate::std::{iter, cmp::Ordering, vec::Vec, ops::BitOr};
 use either::Either;
 
 /// A dynamically sized, write-once (per bit), lazily allocating bitfield.
-#[derive(Eq, PartialEq, Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Bitfield { bits: Vec<u64> }
 
 impl Default for Bitfield {

--- a/src/fuzz_helpers.rs
+++ b/src/fuzz_helpers.rs
@@ -14,6 +14,7 @@
 
 use crate::round::{RoundParams, Round};
 use crate::vote_graph::VoteGraph;
+use crate::voter_set::VoterSet;
 use crate::{Chain, Error, Prevote, Precommit};
 
 #[cfg(not(feature = "std"))]
@@ -282,7 +283,7 @@ pub fn execute_fuzzed_vote(data: &[u8]) {
 	let mut rounds: Vec<Round<Voter, Hash, BlockNumber, Signature>>
 		= voters().iter().map(|_| Round::new(RoundParams {
 			round_number: 0,
-			voters: voters().iter().cloned().map(|v| (v, 1)).collect(),
+			voters: VoterSet::new(voters().iter().cloned().map(|v| (v, 1))).expect("nonempty"),
 			base: (0, 0),
 		})).collect();
 
@@ -411,15 +412,15 @@ pub fn execute_fuzzed_graph(data: &[u8]) {
 	fn new_precommit() -> Vote {
 		Vote { prevote: 0, precommit: 1 }
 	}
-	impl core::ops::AddAssign for Vote {
-		fn add_assign(&mut self, other: Vote) {
+	impl core::ops::AddAssign<&Vote> for Vote {
+		fn add_assign(&mut self, other: &Vote) {
 			self.prevote += other.prevote;
 			self.precommit += other.precommit;
 		}
 	}
 
 	let mut stream = RandomnessStream::new(data);
-	let mut graph = VoteGraph::new(0, 0);
+	let mut graph = VoteGraph::new(0, 0, Vote::default());
 
 	// Record all prevote weights, checking the prevote-ghost.
 	let mut prevote_ghost = None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,11 +66,14 @@ mod std {
 	}
 
 	pub mod fmt {
+		pub use core::fmt::{Display, Result, Formatter};
+
 		pub trait Debug {}
 		impl<T> Debug for T {}
 	}
 }
 
+use crate::std::vec::Vec;
 use crate::voter_set::VoterSet;
 #[cfg(feature = "derive-codec")]
 use parity_scale_codec::{Encode, Decode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@ use crate::voter_set::VoterSet;
 #[cfg(feature = "derive-codec")]
 use parity_scale_codec::{Encode, Decode};
 use round::ImportResult;
-use std::vec::Vec;
 
 /// A prevote for a block and its ancestors.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,13 +30,30 @@
 #[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
+pub mod round;
+pub mod vote_graph;
+pub mod voter_set;
+#[cfg(feature = "std")]
+pub mod voter;
+
+mod bitfield;
+mod weights;
+#[cfg(feature = "std")]
+mod bridge_state;
+#[cfg(any(test, feature = "test-helpers"))]
+mod testing;
+#[cfg(any(test, feature = "fuzz-helpers"))]
+pub mod fuzz_helpers;
 #[cfg(not(feature = "std"))]
 mod std {
 	pub use core::cmp;
 	pub use core::hash;
 	pub use core::iter;
 	pub use core::mem;
+	pub use core::num;
 	pub use core::ops;
 
 	pub mod vec {
@@ -54,35 +71,11 @@ mod std {
 	}
 }
 
-#[cfg(feature = "std")]
-extern crate std;
-
-use crate::std::vec::Vec;
-
-pub mod bitfield;
-
-pub mod round;
-use round::ImportResult;
-
-pub mod vote_graph;
-
-pub mod voter_set;
 use crate::voter_set::VoterSet;
-
-#[cfg(feature = "std")]
-pub mod voter;
-
-#[cfg(feature = "std")]
-mod bridge_state;
-
-#[cfg(any(test, feature = "test-helpers"))]
-mod testing;
-
-#[cfg(any(test, feature = "fuzz-helpers"))]
-pub mod fuzz_helpers;
-
 #[cfg(feature = "derive-codec")]
 use parity_scale_codec::{Encode, Decode};
+use round::ImportResult;
+use std::vec::Vec;
 
 /// A prevote for a block and its ancestors.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -504,12 +497,6 @@ pub fn validate_commit<H, N, S, I, C: Chain<H, N>>(
 	Ok(validation_result)
 }
 
-/// Get the threshold weight given the total voting weight.
-pub fn threshold(total_weight: u64) -> u64 {
-	let faulty = total_weight.saturating_sub(1) / 3;
-	total_weight - faulty
-}
-
 /// Runs the callback with the appropriate `CommitProcessingOutcome` based on
 /// the given `CommitValidationResult`. Outcome is bad if ghost is undefined,
 /// good otherwise.
@@ -592,28 +579,13 @@ impl<H, N, S, Id> HistoricalVotes<H, N, S, Id> {
 	}
 
 	/// Set the number of messages seen before precommiting.
-	pub fn set_precommited_idx(&mut self) {
+	pub fn set_precommitted_idx(&mut self) {
 		self.precommit_idx = Some(self.seen.len() as u64)
 	}
 }
 
 #[cfg(test)]
 mod tests {
-	use super::threshold;
-
-	#[test]
-	fn threshold_is_right() {
-		assert_eq!(threshold(3), 3);
-		assert_eq!(threshold(4), 3);
-		assert_eq!(threshold(5), 4);
-		assert_eq!(threshold(6), 5);
-		assert_eq!(threshold(7), 5);
-		assert_eq!(threshold(10), 7);
-		assert_eq!(threshold(100), 67);
-		assert_eq!(threshold(101), 68);
-		assert_eq!(threshold(102), 69);
-		assert_eq!(threshold(103), 69);
-	}
 
 	#[cfg(feature = "derive-codec")]
 	#[test]

--- a/src/round.rs
+++ b/src/round.rs
@@ -24,7 +24,6 @@ use parity_scale_codec::{Encode, Decode};
 use crate::std::{
 	self,
 	collections::btree_map::{BTreeMap, Entry},
-	hash::Hash,
 	fmt,
 	vec::Vec,
 };
@@ -154,7 +153,7 @@ impl<Id: Ord + Eq + Clone, Vote: Clone + Eq, Signature: Clone + Eq> VoteTracker<
 	}
 
 	// Current vote weight and number of participants.
-	fn participation(&self) -> (u64, usize) {
+	fn participation(&self) -> (VoteWeight, usize) {
 		(self.current_weight, self.votes.len())
 	}
 }
@@ -643,12 +642,12 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 	}
 
 	/// Get the current weight and number of voters who have participated in prevoting.
-	pub fn prevote_participation(&self) -> (u64, usize) {
+	pub fn prevote_participation(&self) -> (VoteWeight, usize) {
 		self.prevote.participation()
 	}
 
 	/// Get the current weight and number of voters who have participated in precommitting.
-	pub fn precommit_participation(&self) -> (u64, usize) {
+	pub fn precommit_participation(&self) -> (VoteWeight, usize) {
 		self.precommit.participation()
 	}
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -14,76 +14,42 @@
 
 //! Logic for a single round of GRANDPA.
 
+mod context;
+
+use context::{Context, VoteNode, Vote};
+
 #[cfg(feature = "derive-codec")]
 use parity_scale_codec::{Encode, Decode};
 
-use crate::bitfield::{Context as BitfieldContext, Bitfield};
 use crate::std::{
-	self, collections::btree_map::{BTreeMap, Entry}, fmt, ops::AddAssign, vec::Vec,
+	self,
+	collections::btree_map::{BTreeMap, Entry},
+	hash::Hash,
+	fmt,
+	vec::Vec,
 };
 use crate::vote_graph::VoteGraph;
-use crate::voter_set::VoterSet;
+use crate::voter_set::{VoterSet, VoterInfo};
+use crate::weights::{VoteWeight, VoterWeight};
 
 use super::{Equivocation, Prevote, Precommit, Chain, BlockNumberOps, HistoricalVotes, Message, SignedMessage};
 
-#[derive(PartialEq, Eq)]
-#[cfg_attr(any(feature = "std", test), derive(
-Debug))]
-struct TotalWeight {
-	prevote: u64,
-	precommit: u64,
+/// The (voting) phases of a round, each corresponding to the type of
+/// votes cast in that phase.
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum Phase {
+	/// The prevote phase in which [`Prevote`]s are cast.
+	Prevote,
+	/// The precommit phase in which [`Precommit`]s are cast.
+	Precommit
 }
 
-#[derive(Clone)]
-#[cfg_attr(any(feature = "std", test), derive(
-Debug))]
-struct VoteWeight {
-	bitfield: Bitfield,
-}
-
-impl Default for VoteWeight {
-	fn default() -> Self {
-		VoteWeight {
-			bitfield: Bitfield::Blank,
-		}
-	}
-}
-
-impl VoteWeight {
-	// compute the total weight of all votes on this node.
-	// equivocators are counted as voting for everything, and must be provided.
-	fn total_weight<Id: Ord + Eq>(
-		&self,
-		equivocators: &Bitfield,
-		voter_set: &VoterSet<Id>,
-	) -> TotalWeight {
-		let with_equivocators = self.bitfield.merge(equivocators)
-			.ok()
-			.expect("this function is never invoked with \
-				equivocators of different canonicality; qed");
-
-		// the unwrap-or is defensive only: there should be registered weights for
-		// all known indices.
-		let (prevote, precommit) = with_equivocators
-			.total_weight(|idx| voter_set.weight_by_index(idx).unwrap_or(0));
-
-		TotalWeight { prevote, precommit }
-	}
-}
-
-impl AddAssign for VoteWeight {
-	fn add_assign(&mut self, rhs: VoteWeight) {
-		self.bitfield = self.bitfield.merge(&rhs.bitfield)
-			.ok()
-			.expect("both bitfields set to same length; qed");
-	}
-}
-
-// votes from a single validator
+/// The observed vote from a single voter.
 enum VoteMultiplicity<Vote, Signature> {
-	// validator voted once.
+	/// A single vote has been observed from the voter.
 	Single(Vote, Signature),
- 	// validator equivocated at least once.
+ 	/// At least two votes have been observed from the voter,
+	/// i.e. an equivocation.
 	Equivocated((Vote, Signature), (Vote, Signature)),
 }
 
@@ -102,7 +68,7 @@ impl<Vote: Eq, Signature: Eq> VoteMultiplicity<Vote, Signature> {
 
 struct VoteTracker<Id: Ord + Eq, Vote, Signature> {
 	votes: BTreeMap<Id, VoteMultiplicity<Vote, Signature>>,
-	current_weight: u64,
+	current_weight: VoteWeight
 }
 
 /// Result of adding a vote.
@@ -115,7 +81,7 @@ impl<Id: Ord + Eq + Clone, Vote: Clone + Eq, Signature: Clone + Eq> VoteTracker<
 	fn new() -> Self {
 		VoteTracker {
 			votes: BTreeMap::new(),
-			current_weight: 0,
+			current_weight: VoteWeight(0),
 		}
 	}
 
@@ -129,12 +95,12 @@ impl<Id: Ord + Eq + Clone, Vote: Clone + Eq, Signature: Clone + Eq> VoteTracker<
 	//
 	// since this struct doesn't track the round-number of votes, that must be set
 	// by the caller.
-	fn add_vote(&mut self, id: Id, vote: Vote, signature: Signature, weight: u64)
+	fn add_vote(&mut self, id: Id, vote: Vote, signature: Signature, weight: VoterWeight)
 		-> AddVoteResult<Vote, Signature>
 	{
 		match self.votes.entry(id) {
 			Entry::Vacant(vacant) => {
-				self.current_weight += weight;
+				self.current_weight = self.current_weight + weight;
 				let multiplicity = vacant.insert(VoteMultiplicity::Single(vote, signature));
 
 				AddVoteResult {
@@ -233,14 +199,12 @@ pub struct RoundParams<Id: Ord + Eq, H, N> {
 
 /// Stores data for a round.
 pub struct Round<Id: Ord + Eq, H: Ord + Eq, N, Signature> {
-	graph: VoteGraph<H, N, VoteWeight>, // DAG of blocks which have been voted on.
+	round_number: u64,
+	context: Context<Id>,
+	graph: VoteGraph<H, N, VoteNode>, // DAG of blocks which have been voted on.
 	prevote: VoteTracker<Id, Prevote<H, N>, Signature>, // tracks prevotes that have been counted
 	precommit: VoteTracker<Id, Precommit<H, N>, Signature>, // tracks precommits
 	historical_votes: HistoricalVotes<H, N, Signature, Id>,
-	round_number: u64,
-	voters: VoterSet<Id>,
-	total_weight: u64,
-	bitfield_context: BitfieldContext,
 	prevote_ghost: Option<(H, N)>, // current memoized prevote-GHOST block
 	precommit_ghost: Option<(H, N)>, // current memoized precommit-GHOST block
 	finalized: Option<(H, N)>, // best finalized block in this round.
@@ -275,21 +239,16 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 	Signature: Eq + Clone,
 {
 	/// Create a new round accumulator for given round number and with given weight.
-	/// Not guaranteed to work correctly unless total_weight more than 3x larger than faulty_weight
 	pub fn new(round_params: RoundParams<Id, H, N>) -> Self {
 		let (base_hash, base_number) = round_params.base;
-		let total_weight = round_params.voters.total_weight();
-		let n_validators = round_params.voters.len();
 
 		Round {
 			round_number: round_params.round_number,
-			total_weight,
-			voters: round_params.voters,
-			graph: VoteGraph::new(base_hash, base_number),
+			context: Context::new(round_params.voters),
+			graph: VoteGraph::new(base_hash, base_number, VoteNode::default()),
 			prevote: VoteTracker::new(),
 			precommit: VoteTracker::new(),
 			historical_votes: HistoricalVotes::new(),
-			bitfield_context: BitfieldContext::new(n_validators),
 			prevote_ghost: None,
 			precommit_ghost: None,
 			finalized: None,
@@ -311,14 +270,14 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 	pub(crate) fn import_prevote<C: Chain<H, N>>(
 		&mut self,
 		chain: &C,
-		vote: Prevote<H, N>,
+		prevote: Prevote<H, N>,
 		signer: Id,
 		signature: Signature,
 	) -> Result<ImportResult<Id, Prevote<H, N>, Signature>, crate::Error> {
 		let mut import_result = ImportResult::default();
 
-		let info = match self.voters.info(&signer) {
-			Some(info) => info,
+		let info = match self.context.voters().get(&signer) {
+			Some(info) => info.clone(),
 			None => return Ok(import_result),
 		};
 
@@ -326,7 +285,7 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		let weight = info.weight();
 
 		let equivocation = {
-			let multiplicity = match self.prevote.add_vote(signer.clone(), vote.clone(), signature.clone(), weight) {
+			let multiplicity = match self.prevote.add_vote(signer.clone(), prevote.clone(), signature.clone(), weight) {
 				AddVoteResult { multiplicity: Some(m), .. } => m,
 				AddVoteResult { duplicated, .. } => {
 					import_result.duplicated = duplicated;
@@ -337,21 +296,17 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 
 			match multiplicity {
 				VoteMultiplicity::Single(single_vote, _) => {
-					let vote_weight = VoteWeight {
-						bitfield: self.bitfield_context.prevote_bitfield(info)
-							.ok()
-							.expect("info is instantiated from same voter set as context; qed"),
-					};
+					let vote = Vote::new(&info, Phase::Prevote);
 
 					self.graph.insert(
 						single_vote.target_hash.clone(),
 						single_vote.target_number,
-						vote_weight,
+						vote,
 						chain,
 					)?;
 
 					// Push the vote into HistoricalVotes.
-					let message = Message::Prevote(vote);
+					let message = Message::Prevote(prevote);
 					let signed_message = SignedMessage { id: signer, signature, message };
 					self.historical_votes.push_vote(signed_message);
 
@@ -359,12 +314,10 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 				}
 				VoteMultiplicity::Equivocated(ref first, ref second) => {
 					// mark the equivocator as such. no need to "undo" the first vote.
-					self.bitfield_context.equivocated_prevote(info)
-						.ok()
-						.expect("info is instantiated from same voter set as bitfield; qed");
+					self.context.equivocated(&info, Phase::Prevote);
 
 					// Push the vote into HistoricalVotes.
-					let message = Message::Prevote(vote);
+					let message = Message::Prevote(prevote);
 					let signed_message = SignedMessage { id: signer.clone(), signature, message };
 					self.historical_votes.push_vote(signed_message);
 
@@ -381,10 +334,9 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		// update prevote-GHOST
 		let threshold = self.threshold();
 		if self.prevote.current_weight >= threshold {
-			let equivocators = self.bitfield_context.equivocators();
 			self.prevote_ghost = self.graph.find_ghost(
 				self.prevote_ghost.take(),
-				|v| v.total_weight(&equivocators, &self.voters).prevote >= threshold,
+				|v| self.context.weight(v, Phase::Prevote) >= threshold,
 			);
 		}
 
@@ -400,21 +352,21 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 	pub(crate) fn import_precommit<C: Chain<H, N>>(
 		&mut self,
 		chain: &C,
-		vote: Precommit<H, N>,
+		precommit: Precommit<H, N>,
 		signer: Id,
 		signature: Signature,
 	) -> Result<ImportResult<Id, Precommit<H, N>, Signature>, crate::Error> {
 		let mut import_result = ImportResult::default();
 
-		let info = match self.voters.info(&signer) {
-			Some(info) => info,
+		let info = match self.context.voters().get(&signer) {
+			Some(info) => info.clone(),
 			None => return Ok(import_result),
 		};
 		import_result.valid_voter = true;
 		let weight = info.weight();
 
 		let equivocation = {
-			let multiplicity = match self.precommit.add_vote(signer.clone(), vote.clone(), signature.clone(), weight) {
+			let multiplicity = match self.precommit.add_vote(signer.clone(), precommit.clone(), signature.clone(), weight) {
 				AddVoteResult { multiplicity: Some(m), .. } => m,
 				AddVoteResult { duplicated, .. } => {
 					import_result.duplicated = duplicated;
@@ -426,20 +378,16 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 
 			match multiplicity {
 				VoteMultiplicity::Single(single_vote, _) => {
-					let vote_weight = VoteWeight {
-						bitfield: self.bitfield_context.precommit_bitfield(info)
-							.ok()
-							.expect("info is instantiated from same voter set as context; qed"),
-					};
+					let vote = Vote::new(&info, Phase::Precommit);
 
 					self.graph.insert(
 						single_vote.target_hash.clone(),
 						single_vote.target_number,
-						vote_weight,
+						vote,
 						chain,
 					)?;
 
-					let message = Message::Precommit(vote);
+					let message = Message::Precommit(precommit);
 					let signed_message = SignedMessage { id: signer, signature, message };
 					self.historical_votes.push_vote(signed_message);
 
@@ -447,12 +395,10 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 				},
 				VoteMultiplicity::Equivocated(ref first, ref second) => {
 					// mark the equivocator as such. no need to "undo" the first vote.
-					self.bitfield_context.equivocated_precommit(info)
-						.ok()
-						.expect("info is instantiated from same voter set as bitfield; qed");
+					self.context.equivocated(&info, Phase::Precommit);
 
 					// Push the vote into HistoricalVotes.
-					let message = Message::Precommit(vote);
+					let message = Message::Precommit(precommit);
 					let signed_message = SignedMessage { id: signer.clone(), signature, message };
 					self.historical_votes.push_vote(signed_message);
 
@@ -486,11 +432,9 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		// update precommit-GHOST
 		let threshold = self.threshold();
 		if self.precommit.current_weight >= threshold {
-			let equivocators = self.bitfield_context.equivocators();
-
 			self.precommit_ghost = self.graph.find_ghost(
 				self.precommit_ghost.take(),
-				|v| v.total_weight(&equivocators, &self.voters).precommit >= threshold,
+				|v| self.context.weight(v, Phase::Precommit) >= threshold,
 			);
 		}
 
@@ -563,27 +507,26 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 	// update the round-estimate and whether the round is completable.
 	fn update(&mut self) {
 		let threshold = self.threshold();
-		if self.prevote.current_weight < threshold { return }
 
-		let remaining_commit_votes = self.total_weight - self.precommit.current_weight;
-		let equivocators = &self.bitfield_context.equivocators();
-
-		let voters = &self.voters;
+		if self.prevote.current_weight < threshold {
+			return
+		}
 
 		let (g_hash, g_num) = match self.prevote_ghost.clone() {
 			None => return,
 			Some(x) => x,
 		};
 
+		let ctx = &self.context;
+
 		// anything new finalized? finalized blocks are those which have both
 		// 2/3+ prevote and precommit weight.
-		let threshold = self.threshold();
 		let current_precommits = self.precommit.current_weight;
-		if current_precommits >= threshold {
+		if current_precommits >= self.threshold() {
 			self.finalized = self.graph.find_ancestor(
 				g_hash.clone(),
 				g_num,
-				|v| v.total_weight(equivocators, voters).precommit >= threshold,
+				|v| ctx.weight(v, Phase::Precommit) >= threshold,
 			);
 		};
 
@@ -592,28 +535,24 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		// equivocations and thus cannot discount weight from validators who
 		// have already voted.
 		let possible_to_precommit = {
-			let tolerated_equivocations = self.total_weight - threshold;
-
 			// find how many more equivocations we could still get.
 			//
 			// it is only important to consider the voters whose votes
 			// we have already seen, because we are assuming any votes we
 			// haven't seen will target this block.
-			let current_equivocations = equivocators
-				.total_weight(|idx| self.voters.weight_by_index(idx).unwrap_or(0))
-				.1;
+			let tolerated_equivocations = ctx.voters().total_weight() - threshold;
+			let current_equivocations = ctx.equivocation_weight(Phase::Precommit);
+			let additional_equiv = tolerated_equivocations - current_equivocations;
+			let remaining_commit_votes = ctx.voters().total_weight() - self.precommit.current_weight;
 
-			let additional_equiv = tolerated_equivocations.saturating_sub(current_equivocations);
-
-			move |weight: &VoteWeight| {
+			move |node: &VoteNode| {
 				// total precommits for this block, including equivocations.
-				let precommitted_for = weight.total_weight(equivocators, voters)
-					.precommit;
+				let precommitted_for = ctx.weight(node, Phase::Precommit);
 
 				// equivocations we could still get are out of those who
 				// have already voted, but not on this block.
 				let possible_equivocations = std::cmp::min(
-					current_precommits.saturating_sub(precommitted_for),
+					current_precommits - precommitted_for,
 					additional_equiv,
 				);
 
@@ -621,8 +560,8 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 				// assuming all remaining actors commit to this block,
 				// and that we get further equivocations
 				let full_possible_weight = precommitted_for
-					.saturating_add(remaining_commit_votes)
-					.saturating_add(possible_equivocations);
+					+ remaining_commit_votes
+					+ possible_equivocations;
 
 				full_possible_weight >= threshold
 			}
@@ -683,9 +622,9 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		self.completable
 	}
 
-	// Threshold number of weight for supermajority.
-	pub fn threshold(&self) -> u64 {
-		self.voters.threshold()
+	/// Threshold weight for supermajority.
+	pub fn threshold(&self) -> VoterWeight {
+		self.context.voters().threshold()
 	}
 
 	/// Return the round base.
@@ -695,12 +634,12 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 
 	/// Return the round voters and weights.
 	pub fn voters(&self) -> &VoterSet<Id> {
-		&self.voters
+		self.context.voters()
 	}
 
 	/// Return the primary voter of the round.
-	pub fn primary_voter(&self) -> &(Id, u64) {
-		self.voters.voter_by_index(self.round_number as usize % self.voters.len())
+	pub fn primary_voter(&self) -> (&Id, &VoterInfo) {
+		self.context.voters().nth_mod(self.round_number as usize)
 	}
 
 	/// Get the current weight and number of voters who have participated in prevoting.
@@ -739,8 +678,8 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 
 	/// Set the number of prevotes and precommits received at the moment of precommiting.
 	/// It should be called inmediatly after precommiting.
-	pub fn set_precommited_index(&mut self) {
-		self.historical_votes.set_precommited_idx()
+	pub fn set_precommitted_index(&mut self) {
+		self.historical_votes.set_precommitted_idx()
 	}
 
 	/// Get the number of prevotes and precommits received at the moment of prevoting.
@@ -751,7 +690,7 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 
 	/// Get the number of prevotes and precommits received at the moment of precommiting.
 	/// Returns None if the precommit wasn't realized.
-	pub fn precommited_index(&self) -> Option<u64> {
+	pub fn precommitted_index(&self) -> Option<u64> {
 		self.historical_votes.precommit_idx
 	}
 }
@@ -762,11 +701,11 @@ mod tests {
 	use crate::testing::chain::{GENESIS_HASH, DummyChain};
 
 	fn voters() -> VoterSet<&'static str> {
-		[
+		VoterSet::new([
 			("Alice", 4),
 			("Bob", 7),
 			("Eve", 3),
-		].iter().cloned().collect()
+		].iter().cloned()).expect("nonempty")
 	}
 
 	#[derive(PartialEq, Eq, Clone, Debug)]
@@ -934,50 +873,6 @@ mod tests {
 	}
 
 	#[test]
-	fn vote_weight_discounts_equivocators() {
-		let v: VoterSet<_> = [
-			(1, 1),
-			(2, 2),
-			(3, 3),
-			(4, 4),
-			(5, 5),
-		].iter().cloned().collect();
-
-		let ctx = BitfieldContext::new(5);
-
-		let equivocators = {
-			let equiv_a = ctx.prevote_bitfield(v.info(&1).unwrap()).unwrap();
-			let equiv_b = ctx.prevote_bitfield(v.info(&5).unwrap()).unwrap();
-
-			equiv_a.merge(&equiv_b).unwrap()
-		};
-
-		let votes = {
-			let vote_a = ctx.prevote_bitfield(v.info(&1).unwrap()).unwrap();
-			let vote_b = ctx.prevote_bitfield(v.info(&2).unwrap()).unwrap();
-			let vote_c = ctx.prevote_bitfield(v.info(&3).unwrap()).unwrap();
-
-			vote_a.merge(&vote_b).unwrap().merge(&vote_c).unwrap()
-		};
-
-		let weight = VoteWeight { bitfield: votes };
-		let vote_weight = weight.total_weight(&equivocators, &v);
-
-		// counts the prevotes from 2, 3, and the equivocations from 1, 5 without
-		// double-counting 1
-		assert_eq!(vote_weight, TotalWeight { prevote: 1 + 5 + 2 + 3, precommit: 0 });
-
-		let votes = weight.bitfield.merge(&ctx.prevote_bitfield(v.info(&5).unwrap()).unwrap()).unwrap();
-
-		let weight = VoteWeight { bitfield: votes };
-		let vote_weight = weight.total_weight(&equivocators, &v);
-
-
-		// adding an extra vote by 5 doesn't increase the count.
-		assert_eq!(vote_weight, TotalWeight { prevote: 1 + 5 + 2 + 3, precommit: 0 });
-	}
-
-	#[test]
 	fn historical_votes_works() {
 		let mut chain = DummyChain::new();
 		chain.push_blocks(GENESIS_HASH, &["A", "B", "C", "D", "E", "F"]);
@@ -1020,7 +915,7 @@ mod tests {
 			Signature("Alice"),
 		).unwrap();
 
-		round.set_precommited_index();
+		round.set_precommitted_index();
 
 		assert_eq!(round.historical_votes(), &HistoricalVotes::new_with(
 			vec![

--- a/src/round/context.rs
+++ b/src/round/context.rs
@@ -17,7 +17,6 @@
 
 use crate::bitfield::{Bitfield, Bit1};
 use crate::voter_set::{VoterSet, VoterInfo};
-use crate::std::hash::Hash;
 use crate::std::ops::AddAssign;
 use crate::weights::VoteWeight;
 
@@ -26,12 +25,12 @@ use super::Phase;
 /// The context of a `Round` in which vote weights are calculated.
 #[cfg_attr(feature = "std", derive(Debug))]
 #[cfg_attr(test, derive(Clone))]
-pub struct Context<T: Eq + Hash> {
+pub struct Context<T: Ord + Eq> {
 	voters: VoterSet<T>,
 	equivocations: Bitfield,
 }
 
-impl<T: Eq + Hash> Context<T> {
+impl<T: Ord + Eq> Context<T> {
 	/// Create a new context for a round with the given set of voters.
 	pub fn new(voters: VoterSet<T>) -> Self {
 		Context {
@@ -101,7 +100,7 @@ impl Vote {
 	/// if it is contained in that set.
 	fn voter<'a, Id>(&'a self, vs: &'a VoterSet<Id>) -> Option<(&'a Id, &'a VoterInfo)>
 	where
-		Id: Eq + Hash
+		Id: Eq + Ord
 	{
 		vs.nth(self.bit.position / 2)
 	}
@@ -141,7 +140,7 @@ impl AddAssign<&Vote> for VoteNode {
 /// of vote-bits in the context of the given set of voters.
 fn weight<V, I>(bits: I, voters: &VoterSet<V>) -> VoteWeight
 where
-	V: Eq + Hash,
+	V: Eq + Ord,
 	I: Iterator<Item = Bit1>
 {
 	let mut total = VoteWeight(0);

--- a/src/round/context.rs
+++ b/src/round/context.rs
@@ -1,3 +1,16 @@
+// Copyright 2019 Parity Technologies (UK) Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! The context of a GRANDPA round tracks the set of voters
 //! and equivocations for the purpose of computing vote weights.

--- a/src/round/context.rs
+++ b/src/round/context.rs
@@ -23,7 +23,7 @@ use crate::weights::VoteWeight;
 use super::Phase;
 
 /// The context of a `Round` in which vote weights are calculated.
-#[cfg_attr(feature = "std", derive(Debug))]
+#[cfg_attr(any(feature = "std", test), derive(Debug))]
 #[cfg_attr(test, derive(Clone))]
 pub struct Context<T: Ord + Eq> {
 	voters: VoterSet<T>,
@@ -110,8 +110,7 @@ impl Vote {
 ///
 /// The weight of any `VoteNode` is always computed in a `Context`,
 /// taking into account equivocations. See [`Context::weight`].
-#[derive(Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, Debug)]
 pub struct VoteNode {
 	bits: Bitfield,
 }
@@ -157,6 +156,7 @@ where
 
 #[cfg(test)]
 mod tests {
+	use crate::std::vec::Vec;
 	use super::*;
 	use quickcheck::*;
 	use rand::Rng;

--- a/src/round/context.rs
+++ b/src/round/context.rs
@@ -1,0 +1,224 @@
+
+//! The context of a GRANDPA round tracks the set of voters
+//! and equivocations for the purpose of computing vote weights.
+
+use crate::bitfield::{Bitfield, Bit1};
+use crate::voter_set::{VoterSet, VoterInfo};
+use crate::std::hash::Hash;
+use crate::std::ops::AddAssign;
+use crate::weights::VoteWeight;
+
+use super::Phase;
+
+/// The context of a `Round` in which vote weights are calculated.
+#[cfg_attr(feature = "std", derive(Debug))]
+#[cfg_attr(test, derive(Clone))]
+pub struct Context<T: Eq + Hash> {
+	voters: VoterSet<T>,
+	equivocations: Bitfield,
+}
+
+impl<T: Eq + Hash> Context<T> {
+	/// Create a new context for a round with the given set of voters.
+	pub fn new(voters: VoterSet<T>) -> Self {
+		Context {
+			voters,
+			equivocations: Bitfield::new(),
+		}
+	}
+
+	/// Get the set of voters.
+	pub fn voters(&self) -> &VoterSet<T> {
+		&self.voters
+	}
+
+	/// Get the weight of observed equivocations in phase `p`.
+	pub fn equivocation_weight(&self, p: Phase) -> VoteWeight {
+		match p {
+			Phase::Prevote => weight(self.equivocations.iter1s_even(), &self.voters),
+			Phase::Precommit => weight(self.equivocations.iter1s_odd(), &self.voters),
+		}
+	}
+
+	/// Record voter `v` as an equivocator in phase `p`.
+	pub fn equivocated(&mut self, v: &VoterInfo, p: Phase) {
+		self.equivocations.set_bit(Vote::new(v, p).bit.position);
+	}
+
+	/// Compute the vote weight on node `n` in phase `p`, taking into account
+	/// equivocations.
+	pub fn weight(&self, n: &VoteNode, p: Phase) -> VoteWeight {
+		if self.equivocations.is_blank() {
+			match p {
+				Phase::Prevote => weight(n.bits.iter1s_even(), &self.voters),
+				Phase::Precommit => weight(n.bits.iter1s_odd(), &self.voters),
+			}
+		} else {
+			match p {
+				Phase::Prevote => {
+					let bits = n.bits.iter1s_merged_even(&self.equivocations);
+					weight(bits, &self.voters)
+				}
+				Phase::Precommit => {
+					let bits = n.bits.iter1s_merged_odd(&self.equivocations);
+					weight(bits, &self.voters)
+				}
+			}
+		}
+	}
+}
+
+/// A single vote that can be incorporated into a `VoteNode`.
+pub struct Vote { bit: Bit1 }
+
+impl Vote {
+	/// Create a new vote cast by voter `v` in phase `p`.
+	pub fn new(v: &VoterInfo, p: Phase) -> Vote {
+		Vote {
+			bit: Bit1 {
+				position: match p {
+					Phase::Prevote => v.position() * 2,
+					Phase::Precommit => v.position() * 2 + 1
+				}
+			}
+		}
+	}
+
+	/// Get the voter who cast the vote from the given voter set,
+	/// if it is contained in that set.
+	fn voter<'a, Id>(&'a self, vs: &'a VoterSet<Id>) -> Option<(&'a Id, &'a VoterInfo)>
+	where
+		Id: Eq + Hash
+	{
+		vs.nth(self.bit.position / 2)
+	}
+}
+
+/// A node on which `Vote`s can be accumulated, for use in a `VoteGraph`.
+///
+/// The weight of any `VoteNode` is always computed in a `Context`,
+/// taking into account equivocations. See [`Context::weight`].
+#[derive(Clone)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct VoteNode {
+	bits: Bitfield,
+}
+
+impl Default for VoteNode {
+	fn default() -> Self {
+		Self {
+			bits: Bitfield::new(),
+		}
+	}
+}
+
+impl AddAssign<&VoteNode> for VoteNode {
+	fn add_assign(&mut self, rhs: &VoteNode) {
+		self.bits.merge(&rhs.bits);
+	}
+}
+
+impl AddAssign<&Vote> for VoteNode {
+	fn add_assign(&mut self, rhs: &Vote) {
+		self.bits.set_bit(rhs.bit.position);
+	}
+}
+
+/// Compute the prevote and precommit weights of a sequence
+/// of vote-bits in the context of the given set of voters.
+fn weight<V, I>(bits: I, voters: &VoterSet<V>) -> VoteWeight
+where
+	V: Eq + Hash,
+	I: Iterator<Item = Bit1>
+{
+	let mut total = VoteWeight(0);
+
+	for bit in bits {
+		let vote = Vote { bit };
+		if let Some((_id, v)) = vote.voter(voters) {
+			total = total + v.weight()
+		}
+	}
+
+	total
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use quickcheck::*;
+	use rand::Rng;
+	use rand::seq::SliceRandom;
+
+	impl Arbitrary for Phase {
+		fn arbitrary<G: Gen>(g: &mut G) -> Self {
+			*[Phase::Prevote, Phase::Precommit].choose(g).unwrap()
+		}
+	}
+
+	impl Arbitrary for Context<usize> {
+		fn arbitrary<G: Gen>(g: &mut G) -> Self {
+			let mut ctx = Context::new(VoterSet::arbitrary(g));
+			let n = g.gen_range(0, ctx.voters.len().get());
+			let equivocators = (0 ..= n)
+				.map(|_| ctx.voters.nth_mod(g.gen()).1.clone())
+				.collect::<Vec<_>>();
+			for v in equivocators {
+				ctx.equivocated(&v, Phase::arbitrary(g))
+			}
+			ctx
+		}
+	}
+
+	#[test]
+	fn vote_voter() {
+		fn prop(vs: VoterSet<usize>, phase: Phase) {
+			for (id, v) in vs.iter() {
+				assert_eq!(Vote::new(v, phase).voter(&vs), Some((id, v)))
+			}
+		}
+
+		quickcheck(prop as fn(_,_))
+	}
+
+	#[test]
+	fn weights() {
+		fn prop(ctx: Context<usize>, phase: Phase, voters: Vec<usize>) {
+			let e = ctx.equivocation_weight(phase);
+			let t = ctx.voters.total_weight();
+
+			// The equivocation weight must never be larger than the total
+			// voter weight.
+			assert!(e <= t);
+
+			// Let a random subset of voters cast a vote, whether already
+			// an equivocator or not.
+			let mut n = VoteNode::default();
+			let mut expected = e;
+			for v in voters {
+				let (_id, v) = ctx.voters.nth_mod(v);
+				let vote = Vote::new(v, phase);
+
+				// We only expect the weight to increase if the voter did not
+				// start out as an equivocator and did not yet vote.
+				if !ctx.equivocations.test_bit(vote.bit.position) &&
+					!n.bits.test_bit(vote.bit.position)
+				{
+					expected = expected + v.weight();
+				}
+
+				n += &vote;
+			}
+
+			// Let the context compute the weight.
+			let w = ctx.weight(&n, phase);
+
+			// A vote-node weight must never be greater than the total voter weight.
+			assert!(w <= t);
+
+			assert_eq!(w, expected);
+		}
+
+		quickcheck(prop as fn(_,_,_))
+	}
+}

--- a/src/vote_graph.rs
+++ b/src/vote_graph.rs
@@ -223,7 +223,7 @@ impl<H, N, V> VoteGraph<H, N, V> where
 					let mut v = V::default();
 					for c in &children {
 						let e = self.entries.get(&c).expect("all children in graph; qed");
-						v += e.cumulative_vote.clone();
+						v += &e.cumulative_vote;
 					}
 					if condition(&v) {
 						return Some((hash, number))
@@ -258,7 +258,7 @@ impl<H, N, V> VoteGraph<H, N, V> where
 			Some(nodes) => {
 				let mut v = Default::default();
 				for node in nodes {
-					v += get_node(&node).cumulative_vote.clone();
+					v += &get_node(&node).cumulative_vote;
 				}
 
 				v
@@ -822,7 +822,7 @@ mod tests {
 	#[test]
 	fn find_ancestor_is_largest() {
 		let mut chain = DummyChain::new();
-		let mut tracker = VoteGraph::<_,_,u32>::new(GENESIS_HASH, 0);
+		let mut tracker = VoteGraph::new(GENESIS_HASH, 0, 0);
 
 		chain.push_blocks(GENESIS_HASH, &["A"]);
 		chain.push_blocks(GENESIS_HASH, &["B"]);

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -126,7 +126,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 			Voting::Primary
 		} else if round_data.voter_id
 			.as_ref()
-			.map_or(false, |id| votes.voters().contains_key(id))
+			.map_or(false, |id| votes.voters().contains(id))
 		{
 			Voting::Yes
 		} else {
@@ -510,7 +510,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 						debug!(target: "afg", "Casting precommit for round {}", self.votes.number());
 						let precommit = self.construct_precommit();
 						self.env.precommitted(self.round_number(), precommit.clone())?;
-						self.votes.set_precommited_index();
+						self.votes.set_precommitted_index();
 						self.outgoing.push(Message::Precommit(precommit));
 					}
 					self.state = Some(State::Precommitted);

--- a/src/voter_set.rs
+++ b/src/voter_set.rs
@@ -128,7 +128,8 @@ impl<Id: Eq> VoterSet<Id> {
 	/// Get the nth voter in the set, modulo the size of the set,
 	/// as per the associated total order.
 	pub fn nth_mod(&self, n: usize) -> (&Id, &VoterInfo) {
-		self.nth(n % self.order.len()).unwrap()
+		self.nth(n % self.order.len())
+			.expect("set is nonempty and n % len < len; qed")
 	}
 
 	/// Get the nth voter in the set, if any.

--- a/src/voter_set.rs
+++ b/src/voter_set.rs
@@ -28,8 +28,7 @@ use crate::weights::VoterWeight;
 /// A `VoterSet` identifies all voters that are permitted to vote in a round
 /// of the protocol and their associated weights. A `VoterSet` is furthermore
 /// equipped with a total order, given by the ordering of the voter's IDs.
-#[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct VoterSet<Id: Eq + Ord> {
 	/// The voters in the set.
 	voters: BTreeMap<Id, VoterInfo>,
@@ -156,9 +155,7 @@ impl<Id: Eq + Ord> VoterSet<Id> {
 }
 
 /// Information about a voter in a `VoterSet`.
-#[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(any(feature = "std", test), derive(
-Debug))]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct VoterInfo {
 	position: usize,
 	weight: VoterWeight,

--- a/src/voter_set.rs
+++ b/src/voter_set.rs
@@ -30,7 +30,7 @@ use crate::weights::VoterWeight;
 /// equipped with a total order, given by the ordering of the voter's IDs.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct VoterSet<Id: Eq> {
+pub struct VoterSet<Id: Eq + Ord> {
 	/// The voters in the set.
 	voters: BTreeMap<Id, VoterInfo>,
 	/// The total order associated with the keys in `voters`.
@@ -41,7 +41,7 @@ pub struct VoterSet<Id: Eq> {
 	total_weight: VoterWeight,
 }
 
-impl<Id: Eq> VoterSet<Id> {
+impl<Id: Eq + Ord> VoterSet<Id> {
 	/// Create a voter set from a weight distribution produced by the given iterator.
 	///
 	/// If the distribution contains multiple weights for the same voter ID, they are
@@ -59,7 +59,7 @@ impl<Id: Eq> VoterSet<Id> {
 		let weights = weights.into_iter();
 
 		// Populate the voter set, thereby calculating the total weight.
-		let mut voters = BTreeMap::with_capacity(weights.size_hint().0);
+		let mut voters = BTreeMap::new();
 		let mut total_weight = 0u64;
 		for (id, weight) in weights {
 			if let Some(w) = NonZeroU64::new(weight) {

--- a/src/voter_set.rs
+++ b/src/voter_set.rs
@@ -48,13 +48,9 @@ impl<Id: Eq> VoterSet<Id> {
 	/// understood to be partial weights and are accumulated. As a result, the
 	/// order in which the iterator produces the weights is irrelevant.
 	///
-	/// Returns `None` if the iterator produced no non-zero weights, i.e.
-	/// the voter set would be empty.
-	///
-	/// # Panics
-	///
-	/// If the total voter weight exceeds `u64::MAX`.
-	///
+	/// Returns `None` if the iterator does not yield a valid voter set, which is
+	/// the case if it either produced no non-zero weights or, i.e. the voter set
+	/// would be empty, or if the total voter weight exceeds `u64::MAX`.
 	pub fn new<I>(weights: I) -> Option<Self>
 	where
 		Id: Ord + Clone,
@@ -70,7 +66,7 @@ impl<Id: Eq> VoterSet<Id> {
 				// Prevent construction of inconsistent voter sets by checking
 				// for weight overflow (not just in debug mode). The protocol
 				// should never run with such voter sets.
-				total_weight = total_weight.checked_add(weight).expect("Voter weight overflow");
+				total_weight = total_weight.checked_add(weight)?;
 				match voters.entry(id) {
 					Entry::Vacant(e) => {
 						e.insert(VoterInfo {

--- a/src/voter_set.rs
+++ b/src/voter_set.rs
@@ -12,149 +12,241 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Maintains the `VoterSet` of the blockchain.
-//!
-//! See docs on `VoterSet` for more information.
+//! Implementation of a `VoterSet`, representing the complete set
+//! of voters and their weights in the context of a round of the
+//! protocol.
 
-use crate::std::{self, collections::BTreeMap, vec::Vec};
+use crate::std::{
+	collections::{BTreeMap, btree_map::Entry},
+	num::{NonZeroU64, NonZeroUsize},
+	vec::Vec
+};
+use crate::weights::VoterWeight;
 
-use super::threshold;
-
-/// A voter set, with accompanying indices.
+/// A (non-empty) set of voters and associated weights.
+///
+/// A `VoterSet` identifies all voters that are permitted to vote in a round
+/// of the protocol and their associated weights. A `VoterSet` is furthermore
+/// equipped with a total order, given by the ordering of the voter's IDs.
 #[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(any(feature = "std", test), derive(Debug))]
-pub struct VoterSet<Id: Ord + Eq> {
-	weights: BTreeMap<Id, VoterInfo>,
-	voters: Vec<(Id, u64)>,
-	threshold: u64,
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct VoterSet<Id: Eq> {
+	/// The voters in the set.
+	voters: BTreeMap<Id, VoterInfo>,
+	/// The total order associated with the keys in `voters`.
+	order: Vec<Id>,
+	/// The required weight threshold for supermajority w.r.t. this set.
+	threshold: VoterWeight,
+	/// The total weight of all voters.
+	total_weight: VoterWeight,
 }
 
-impl<Id: Ord + Eq> VoterSet<Id> {
-	/// Get the voter info for a voter.
-	pub fn info<'a>(&'a self, id: &Id) -> Option<&'a VoterInfo> {
-		self.weights.get(id)
-	}
+impl<Id: Eq> VoterSet<Id> {
+	/// Create a voter set from a weight distribution produced by the given iterator.
+	///
+	/// If the distribution contains multiple weights for the same voter ID, they are
+	/// understood to be partial weights and are accumulated. As a result, the
+	/// order in which the iterator produces the weights is irrelevant.
+	///
+	/// Returns `None` if the iterator produced no non-zero weights, i.e.
+	/// the voter set would be empty.
+	///
+	/// # Panics
+	///
+	/// If the total voter weight exceeds `u64::MAX`.
+	///
+	pub fn new<I>(weights: I) -> Option<Self>
+	where
+		Id: Ord + Clone,
+		I: IntoIterator<Item = (Id, u64)>
+	{
+		let weights = weights.into_iter();
 
-	/// Get the length of the set.
-	pub fn len(&self) -> usize { self.voters.len() }
-
-	/// Whether the set contains the key.
-	pub fn contains_key(&self, id: &Id) -> bool {
-		self.weights.contains_key(id)
-	}
-
-	// Get voter by index.
-	pub fn voter_by_index(&self, idx: usize) -> &(Id, u64) {
-		&self.voters[idx]
-	}
-
-	/// Get voter info by index.
-	pub fn weight_by_index(&self, idx: usize) -> Option<u64> {
-		self.voters.get(idx).map(|&(_, weight)| weight)
-	}
-
-	/// Get the threshold weight.
-	pub fn threshold(&self) -> u64 { self.threshold }
-
-	/// Get the total weight.
-	pub fn total_weight(&self) -> u64 {
-		self.voters.iter().map(|&(_, weight)| weight).sum()
-	}
-
-	/// Get the voters.
-	pub fn voters(&self) -> &[(Id, u64)] {
-		&self.voters
-	}
-}
-
-impl<Id: Eq + Clone + Ord> std::iter::FromIterator<(Id, u64)> for VoterSet<Id> {
-	fn from_iter<I: IntoIterator<Item = (Id, u64)>>(iterable: I) -> Self {
-		let iter = iterable.into_iter();
-		let (lower, _) = iter.size_hint();
-
-		let mut voters = Vec::with_capacity(lower);
-		let mut weights = BTreeMap::new();
-
-		let mut total_weight = 0;
-		for (id, weight) in iter {
-			voters.push((id.clone(), weight));
-			total_weight += weight;
+		// Populate the voter set, thereby calculating the total weight.
+		let mut voters = BTreeMap::with_capacity(weights.size_hint().0);
+		let mut total_weight = 0u64;
+		for (id, weight) in weights {
+			if let Some(w) = NonZeroU64::new(weight) {
+				// Prevent construction of inconsistent voter sets by checking
+				// for weight overflow (not just in debug mode). The protocol
+				// should never run with such voter sets.
+				total_weight = total_weight.checked_add(weight).expect("Voter weight overflow");
+				match voters.entry(id) {
+					Entry::Vacant(e) => {
+						e.insert(VoterInfo {
+							position: 0, // The total order is determined afterwards.
+							weight: VoterWeight(w)
+						});
+					},
+					Entry::Occupied(mut e) => {
+						let v = e.get_mut();
+						let n = v.weight.get() + weight;
+						let w = NonZeroU64::new(n).expect("nonzero + nonzero is nonzero");
+						v.weight = VoterWeight(w);
+					}
+				}
+			}
 		}
 
-		voters.sort_unstable();
+		if voters.is_empty() {
+			// No non-zero weights; the set would be empty.
+			return None
+		}
 
-		for (idx, (id, weight)) in voters.iter().enumerate() {
-			weights.insert(id.clone(), VoterInfo { canon_idx: idx, weight: *weight });
+		let total_weight = VoterWeight::new(total_weight).expect("voters nonempty; qed");
+
+		// Establish the total order on the set based on the voter IDs.
+		let mut order = voters.keys().cloned().collect::<Vec<_>>();
+		order.sort_unstable();
+		for (i, id) in order.iter().enumerate() {
+			voters.get_mut(id).expect("def. of order; qed").position = i;
 		}
 
 		let threshold = threshold(total_weight);
-		VoterSet { weights, voters, threshold }
+
+		Some(VoterSet { voters, order, total_weight, threshold })
+	}
+
+	/// Get the voter info for the voter with the given ID, if any.
+	pub fn get(&self, id: &Id) -> Option<&VoterInfo> {
+		self.voters.get(id)
+	}
+
+	/// Get the size of the set.
+	pub fn len(&self) -> NonZeroUsize {
+		unsafe {
+			// SAFETY: By VoterSet::new()
+			NonZeroUsize::new_unchecked(self.order.len())
+		}
+	}
+
+	/// Whether the set contains a voter with the given ID.
+	pub fn contains(&self, id: &Id) -> bool {
+		self.voters.contains_key(id)
+	}
+
+	/// Get the nth voter in the set, modulo the size of the set,
+	/// as per the associated total order.
+	pub fn nth_mod(&self, n: usize) -> (&Id, &VoterInfo) {
+		self.nth(n % self.order.len()).unwrap()
+	}
+
+	/// Get the nth voter in the set, if any.
+	///
+	/// Returns `None` if `n >= len`.
+	pub fn nth(&self, n: usize) -> Option<(&Id, &VoterInfo)> {
+		self.order.get(n)
+			.and_then(|i| self.voters.get(i)
+				.map(|info| (i, info)))
+	}
+
+	/// Get the threshold vote weight required for supermajority
+	/// w.r.t. this set of voters.
+	pub fn threshold(&self) -> VoterWeight {
+		self.threshold
+	}
+
+	/// Get the total weight of all voters.
+	pub fn total_weight(&self) -> VoterWeight {
+		self.total_weight
+	}
+
+	/// Get an iterator over the voters in the set, as given by
+	/// the associated total order.
+	pub fn iter(&self) -> impl Iterator<Item = (&Id, &VoterInfo)> {
+		(0 .. self.order.len()).map(move |n| self.nth_mod(n))
 	}
 }
 
+/// Information about a voter in a `VoterSet`.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(
 Debug))]
 pub struct VoterInfo {
-	canon_idx: usize,
-	weight: u64,
+	position: usize,
+	weight: VoterWeight,
 }
 
 impl VoterInfo {
-	/// Get the canonical index of the voter.
-	pub fn canon_idx(&self) -> usize { self.canon_idx }
+	/// Get the position of the voter in the total order associated
+	/// with the `VoterSet` from which the `VoterInfo` was obtained.
+	pub fn position(&self) -> usize { self.position }
 
 	/// Get the weight of the voter.
-	pub fn weight(&self) -> u64 { self.weight }
+	pub fn weight(&self) -> VoterWeight { self.weight }
 }
 
+/// Compute the threshold weight given the total voting weight.
+fn threshold(total_weight: VoterWeight) -> VoterWeight {
+	let faulty = total_weight.get().saturating_sub(1) / 3;
+	VoterWeight::new(total_weight.get() - faulty).expect("subtrahend > minuend; qed")
+}
 
 #[cfg(test)]
 mod tests {
+	use crate::std::iter;
 	use super::*;
+	use quickcheck::*;
+	use rand::{thread_rng, Rng, seq::SliceRandom};
 
-	#[test]
-	fn voters_are_sorted() {
-		let v1: VoterSet<usize> = [
-			(1, 5),
-			(4, 1),
-			(3, 9),
-			(5, 7),
-			(9, 9),
-			(2, 7),
-		].iter().cloned().collect();
-
-		let v2: VoterSet<usize> = [
-			(1, 5),
-			(2, 7),
-			(3, 9),
-			(4, 1),
-			(5, 7),
-			(9, 9),
-		].iter().cloned().collect();
-
-		assert_eq!(v1, v2);
+	impl<Id: Arbitrary + Eq + Ord> Arbitrary for VoterSet<Id> {
+		fn arbitrary<G: Gen>(g: &mut G) -> VoterSet<Id> {
+			let mut ids = Vec::<Id>::arbitrary(g);
+			if ids.is_empty() {
+				ids.push(Id::arbitrary(g))
+			}
+			let weights = iter::from_fn(move || Some(g.gen::<u32>() as u64));
+			VoterSet::new(ids.into_iter().zip(weights)).expect("nonempty")
+		}
 	}
 
 	#[test]
-	fn voter_by_index_works() {
-		let v: VoterSet<usize> = [
-			(1, 5),
-			(4, 1),
-			(3, 9),
-			(5, 7),
-			(9, 9),
-			(2, 7),
-		].iter().cloned().collect();
+	fn consistency() {
+		fn prop(s: VoterSet<usize>) -> bool {
+			s.order.len() == s.voters.len() &&
+			s.order.iter().all(|id| s.voters.contains_key(id))
+		}
 
-		assert_eq!(v.len(), 6);
-		assert_eq!(v.total_weight(), 38);
+		quickcheck(prop as fn(_) -> _)
+	}
 
-		assert_eq!(v.voter_by_index(0), &(1, 5));
-		assert_eq!(v.voter_by_index(1), &(2, 7));
-		assert_eq!(v.voter_by_index(2), &(3, 9));
-		assert_eq!(v.voter_by_index(3), &(4, 1));
-		assert_eq!(v.voter_by_index(4), &(5, 7));
-		assert_eq!(v.voter_by_index(5), &(9, 9));
+	#[test]
+	fn equality() {
+		fn prop(mut v: Vec<(usize, u64)>) {
+			if let Some(v1) = VoterSet::new(v.clone()) {
+				v.shuffle(&mut thread_rng());
+				let v2 = VoterSet::new(v).expect("nonempty");
+				assert_eq!(v1, v2)
+			} else {
+				assert!(v.iter().all(|(_, w)| w == &0))
+			}
+		}
+
+		quickcheck(prop as fn(_))
+	}
+
+	#[test]
+	fn total_weight() {
+		fn prop(v: Vec<(usize, u64)>) {
+			let expected = VoterWeight::new(v.iter().map(|(_, weight)| *weight).sum());
+			if let Some(v1) = VoterSet::new(v) {
+				assert_eq!(Some(v1.total_weight()), expected)
+			} else {
+				assert_eq!(expected, None)
+			}
+		}
+
+		quickcheck(prop as fn(_))
+	}
+
+	#[test]
+	fn min_threshold() {
+		fn prop(v: VoterSet<usize>) -> bool {
+			let t = v.threshold.get();
+			let w = v.total_weight.get();
+			t >= 2 * (w / 3) + (w % 3)
+		}
+
+		quickcheck(prop as fn(_) -> _);
 	}
 }

--- a/src/voter_set.rs
+++ b/src/voter_set.rs
@@ -90,9 +90,8 @@ impl<Id: Eq + Ord> VoterSet<Id> {
 
 		let total_weight = VoterWeight::new(total_weight).expect("voters nonempty; qed");
 
-		// Establish the total order on the set based on the voter IDs.
-		let mut order = voters.keys().cloned().collect::<Vec<_>>();
-		order.sort_unstable();
+		// Establish the total order based on the voter IDs.
+		let order = voters.keys().cloned().collect::<Vec<_>>();
 		for (i, id) in order.iter().enumerate() {
 			voters.get_mut(id).expect("def. of order; qed").position = i;
 		}

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -1,3 +1,16 @@
+// Copyright 2019 Parity Technologies (UK) Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! This module lays out the rules for the arithmetic of vote(r) weights.
 

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -17,10 +17,17 @@
 use crate::std::ops::{Add, Sub};
 use crate::std::cmp::Ordering;
 use crate::std::num::NonZeroU64;
+use crate::std::fmt;
 
 /// The accumulated weight of any number of voters (possibly none).
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct VoteWeight(pub u64);
+
+impl fmt::Display for VoteWeight {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "{}", self.0)
+	}
+}
 
 impl Add for VoteWeight {
 	type Output = Self;
@@ -71,6 +78,12 @@ impl PartialOrd<VoterWeight> for VoteWeight {
 /// Having a non-zero weight is part of the definition of being a voter.
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub struct VoterWeight(pub NonZeroU64);
+
+impl fmt::Display for VoterWeight {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "{}", self.0)
+	}
+}
 
 impl VoterWeight {
 	pub fn new(weight: u64) -> Option<Self> {

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -1,0 +1,86 @@
+
+//! This module lays out the rules for the arithmetic of vote(r) weights.
+
+use crate::std::ops::{Add, Sub};
+use crate::std::cmp::Ordering;
+use crate::std::num::NonZeroU64;
+
+/// The accumulated weight of any number of voters (possibly none).
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct VoteWeight(pub u64);
+
+impl Add for VoteWeight {
+	type Output = Self;
+
+	fn add(self, rhs: Self) -> Self {
+		VoteWeight(self.0.saturating_add(rhs.0))
+	}
+}
+
+impl Add<VoterWeight> for VoteWeight {
+	type Output = Self;
+
+	fn add(self, rhs: VoterWeight) -> Self {
+		VoteWeight(self.0.saturating_add(rhs.0.get()))
+	}
+}
+
+impl Sub for VoteWeight {
+	type Output = Self;
+
+	fn sub(self, rhs: Self) -> Self {
+		VoteWeight(self.0.saturating_sub(rhs.0))
+	}
+}
+
+impl Sub<VoterWeight> for VoteWeight {
+	type Output = Self;
+
+	fn sub(self, rhs: VoterWeight) -> Self {
+		self - VoteWeight(rhs.get())
+	}
+}
+
+impl PartialEq<VoterWeight> for VoteWeight {
+	fn eq(&self, other: &VoterWeight) -> bool {
+		self.0 == other.get()
+	}
+}
+
+impl PartialOrd<VoterWeight> for VoteWeight {
+	fn partial_cmp(&self, other: &VoterWeight) -> Option<Ordering> {
+		Some(self.0.cmp(&other.0.get()))
+	}
+}
+
+/// The (non-zero) weight of one or more voters.
+///
+/// Having a non-zero weight is part of the definition of being a voter.
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub struct VoterWeight(pub NonZeroU64);
+
+impl VoterWeight {
+	pub fn new(weight: u64) -> Option<Self> {
+		NonZeroU64::new(weight).map(Self)
+	}
+
+	pub fn get(&self) -> u64 {
+		self.0.get()
+	}
+}
+
+impl Sub<VoteWeight> for VoterWeight {
+	type Output = VoteWeight;
+
+	fn sub(self, rhs: VoteWeight) -> VoteWeight {
+		VoteWeight(self.0.get()) - rhs
+	}
+}
+
+impl Sub<VoterWeight> for VoterWeight {
+	type Output = VoteWeight;
+
+	fn sub(self, rhs: VoterWeight) -> VoteWeight {
+		VoteWeight(self.0.get()) - VoteWeight(rhs.get())
+	}
+}


### PR DESCRIPTION
This is a proposal for a refactoring (or rather rewrite) of the `voter_set` and `bitfield` modules alongside smaller related changes in the `round` and `vote_graph`, targeting the `v0.11.0` branch (i.e. based on https://github.com/paritytech/finality-grandpa/pull/81).

Below is a rough outline of the main changes.

## Bitfield

  * Simplify definition, as `Bitfield::Blank` and `LiveBitfield(vec![])`
    are equivalent.
  * Dynamically-sized with lazy allocation makes for a more ergonomic
    API and keeps bitfields smaller with larger voter sets. The reasoning
    here is the following: If there are few voters, most votes
    are likely on the same or very few nodes / blocks but in that case bitfields
    are almost never resized anyway. As there are more and more voters,
    votes are likely spread across more and more nodes / blocks and thus not
    all nodes need a full-sized bitfield (whose size grows with the voter set).
  * Avoid allocations when merging bitfields. Previously merging would
    always allocate a new bitfield, now the other bitfield is merged
    into `self` and only allocates if `self` needs to be resized.
  * Avoid allocations when recording votes in the vote graph and computing weights.
    Previously both recording of new votes and computing weights
    involved creating and merging bitfields. Now incorporating a
    vote into an existing vote-node is a `set_bit` operation while
    computing the vote weight on a node is based on a bitfield-merging
    iterator that does not allocate.
  * Better tests.

## VoterSet

  * Make it impossible to construct inconsistent sets as well as
    empty sets. Both were previously possible.
  * Better tests.

## Related changes

  * Introduce a `weights` module for encapsulating vote-weight
    arithmetic behind newtypes.
  * Introduce a `round::context` module for encapsulating the
    context of a round in which vote weights are computed,
    consisting of the voter set and recorded equivocations.
    This combines some functionality from the previous `bitfield`
    module and some from the parent `round` module.
