### PR TITLE
build: fix hashbrown features under no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4"
 parking_lot = { version = "0.9", optional = true }
 parity-scale-codec = { version = "1.0.3", optional = true, default-features = false, features = ["derive"] }
 num = { package = "num-traits", version = "0.2", default-features = false }
-hashbrown = { version = "0.6.3", default-features = false }
+hashbrown = { version = "0.6.3", default-features = false, features = ["ahash", "inline-more"] }
 
 [dev-dependencies]
 exit-future = "0.1.2"


### PR DESCRIPTION
The default set of features for hashbrown is: "ahash", "ahash-compile-time-rng", "inline-more".
Without "ahash" the HashMap API isn't implemented, so no-std build was broken by #90. 