### PR TITLE
derive debug under no-std for some types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,9 +85,7 @@ pub mod fuzz_helpers;
 use parity_scale_codec::{Encode, Decode};
 
 /// A prevote for a block and its ancestors.
-#[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(any(feature = "std", test), derive(
-Debug))]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
 pub struct Prevote<H, N> {
 	/// The target block's hash.
@@ -103,9 +101,7 @@ impl<H, N> Prevote<H, N> {
 }
 
 /// A precommit for a block and its ancestors.
-#[derive(Clone, PartialEq, Eq)]
-#[cfg_attr(any(feature = "std", test), derive(
-Debug))]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
 pub struct Precommit<H, N> {
 	/// The target block's hash.
@@ -213,9 +209,7 @@ pub trait Chain<H: Eq, N: Copy + BlockNumberOps> {
 }
 
 /// An equivocation (double-vote) in a given round.
-#[derive(Clone, PartialEq)]
-#[cfg_attr(any(feature = "std", test), derive(
-Debug))]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
 pub struct Equivocation<Id, V, S> {
 	/// The round number equivocated in.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@ pub struct Equivocation<Id, V, S> {
 	/// The identity of the equivocator.
 	pub identity: Id,
 	/// The first vote in the equivocation.
-	pub	first: (V, S),
+	pub first: (V, S),
 	/// The second vote in the equivocation.
 	pub second: (V, S),
 }


### PR DESCRIPTION
These types are part of parameters used in the runtime for equivocation reporting and therefore need to implement `Debug`. I kept the guards for `std` for the rest of the types should we remove them now that we support `Debug` under `no-std`?