### PR TITLE
A warning and a comment

### DIFF
--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -559,7 +559,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 						Ok(ancestry) => {
 							let to_sub = p_num + N::one();
 
-							let offset: usize = if   last_prevote_g.1 < to_sub {
+							let offset: usize = if last_prevote_g.1 < to_sub {
 								0
 							} else {
 								(last_prevote_g.1 - to_sub).as_()
@@ -576,8 +576,8 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 							warn!(target: "afg",
 								"Possible case of massive equivocation: \
 								last round prevote GHOST: {:?} is not a descendant of last round estimate: {:?}",
-								&last_prevote_g,
-								&last_round_estimate,
+								last_prevote_g,
+								last_round_estimate,
 							);
 
 							last_round_estimate.0

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -361,8 +361,8 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 			}
 			Message::PrimaryPropose(primary) => {
 				let primary_id = self.votes.primary_voter().0.clone();
-                // note that id here refers to party which has casted the vote
-			    // and not the id of party which has received the vote message.
+				// note that id here refers to the party which has cast the vote
+				// and not the id of the party which has received the vote message.
 				if id == primary_id {
 					self.primary_block = Some((primary.target_hash, primary.target_number));
 				}
@@ -571,12 +571,17 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 								last_round_estimate.0
 							}
 						}
-						Err(crate::Error::NotDescendent) =>
-                        {
-                            //This is only possible in case of massive equivocation
-			                warn!(target: "afg", "Possible case of massive equivocation: last round prevote GHOST {:?} is not a descendant of last round estimate {:?}", &last_prevote_g, &last_round_estimate);
-                            last_round_estimate.0
-                        }
+						Err(crate::Error::NotDescendent) => {
+							// This is only possible in case of massive equivocation
+							warn!(target: "afg",
+								"Possible case of massive equivocation: \
+								last round prevote GHOST: {:?} is not a descendant of last round estimate: {:?}",
+								&last_prevote_g,
+								&last_round_estimate,
+							);
+
+							last_round_estimate.0
+						}
 					}
 				}
 			}


### PR DESCRIPTION
- Added a warning for when the prevote ghost happens not to be the descendent of  the estimate. According to @AlistairStewart this only can happen when there is a massive equivocation so it desrves the extra attention if ever we fell into that case.

- Added a comment to make the code of handling priamry propose more clear following the advice of @andresilva.