### PR TITLE
Expose voter state

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! Equivocation detection and vote-set management is done in the `round` module.
 //! The work for actually casting votes is done in the `voter` module.
 
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]
@@ -90,6 +91,7 @@ pub struct Prevote<H, N> {
 }
 
 impl<H, N> Prevote<H, N> {
+	/// Create a new Prevote from the targets block's hash and number.
 	pub fn new(target_hash: H, target_number: N) -> Self {
 		Prevote { target_hash, target_number }
 	}
@@ -106,6 +108,7 @@ pub struct Precommit<H, N> {
 }
 
 impl<H, N> Precommit<H, N> {
+	/// Create a new Precommit from the targets block's hash and number.
 	pub fn new(target_hash: H, target_number: N) -> Self {
 		Precommit { target_hash, target_number }
 	}
@@ -123,14 +126,18 @@ pub struct PrimaryPropose<H, N> {
 }
 
 impl<H, N> PrimaryPropose<H, N> {
+	/// Create a new primary proposed block from the tarets block's hash and
+	/// number.
 	pub fn new(target_hash: H, target_number: N) -> Self {
 		PrimaryPropose { target_hash, target_number }
 	}
 }
 
+/// Top-level Error type
 #[derive(Clone, PartialEq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
 pub enum Error {
+	/// Raised when the block is not a descendent of the given base block.
 	NotDescendent,
 }
 
@@ -226,7 +233,7 @@ pub enum Message<H, N> {
 	/// A precommit message.
 	#[cfg_attr(feature = "derive-codec", codec(index = "1"))]
 	Precommit(Precommit<H, N>),
-	// Primary proposed block.
+	/// Primary proposed block.
 	#[cfg_attr(feature = "derive-codec", codec(index = "2"))]
 	PrimaryPropose(PrimaryPropose<H, N>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub struct Prevote<H, N> {
 }
 
 impl<H, N> Prevote<H, N> {
-	/// Create a new Prevote from the targets block's hash and number.
+	/// Create a new prevote for the given block (hash and number).
 	pub fn new(target_hash: H, target_number: N) -> Self {
 		Prevote { target_hash, target_number }
 	}
@@ -108,7 +108,7 @@ pub struct Precommit<H, N> {
 }
 
 impl<H, N> Precommit<H, N> {
-	/// Create a new Precommit from the targets block's hash and number.
+	/// Create a new precommit for the given block (hash and number).
 	pub fn new(target_hash: H, target_number: N) -> Self {
 		Precommit { target_hash, target_number }
 	}
@@ -126,14 +126,13 @@ pub struct PrimaryPropose<H, N> {
 }
 
 impl<H, N> PrimaryPropose<H, N> {
-	/// Create a new primary proposed block from the tarets block's hash and
-	/// number.
+	/// Create a new primary proposal for the given block (hash and number).
 	pub fn new(target_hash: H, target_number: N) -> Self {
 		PrimaryPropose { target_hash, target_number }
 	}
 }
 
-/// Top-level Error type
+/// Top-level error type used by this crate.
 #[derive(Clone, PartialEq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
 pub enum Error {
@@ -233,7 +232,7 @@ pub enum Message<H, N> {
 	/// A precommit message.
 	#[cfg_attr(feature = "derive-codec", codec(index = "1"))]
 	Precommit(Precommit<H, N>),
-	/// Primary proposed block.
+	/// A primary proposal message.
 	#[cfg_attr(feature = "derive-codec", codec(index = "2"))]
 	PrimaryPropose(PrimaryPropose<H, N>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ impl<H, N> PrimaryPropose<H, N> {
 #[derive(Clone, PartialEq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
 pub enum Error {
-	/// Raised when the block is not a descendent of the given base block.
+	/// The block is not a descendent of the given base block.
 	NotDescendent,
 }
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -174,7 +174,7 @@ pub struct State<H, N> {
 }
 
 impl<H: Clone, N: Clone> State<H, N> {
-	// Genesis state.
+	/// Genesis state.
 	pub fn genesis(genesis: (H, N)) -> Self {
 		State {
 			prevote_ghost: Some(genesis.clone()),
@@ -415,7 +415,7 @@ impl<Id, H, N, Signature> Round<Id, H, N, Signature> where
 		Ok(import_result)
 	}
 
-	// Get current
+	/// Return the current state.
 	pub fn state(&self) -> State<H, N> {
 		State {
 			prevote_ghost: self.prevote_ghost.clone(),

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -199,17 +199,16 @@ pub mod environment {
 	}
 
 	impl crate::voter::Environment<&'static str, u32> for Environment {
-		type Timer = Pin<Box<dyn Future<Output = Result<(), Error>> + Unpin + Send + Sync>>;
+		type Timer = Box<dyn Future<Output = Result<(), Error>> + Unpin + Send + Sync>;
 		type Id = Id;
 		type Signature = Signature;
-		type In = Pin<
+		type In =
 			Box<
 				dyn Stream<Item = Result<SignedMessage<&'static str, u32, Signature, Id>, Error>>
 					+ Unpin
 					+ Send
 					+ Sync,
-			>,
-		>;
+			>;
 		type Out =
 			Pin<Box<dyn Sink<Message<&'static str, u32>, Error = Error> + Send + Sync + 'static>>;
 		type Error = Error;
@@ -220,9 +219,9 @@ pub mod environment {
 			let (incoming, outgoing) = self.network.make_round_comms(round, self.local_id);
 			RoundData {
 				voter_id: Some(self.local_id),
-				prevote_timer: Box::pin(Delay::new(GOSSIP_DURATION).map(Ok)),
-				precommit_timer: Box::pin(Delay::new(GOSSIP_DURATION + GOSSIP_DURATION).map(Ok)),
-				incoming: Box::pin(incoming),
+				prevote_timer: Box::new(Delay::new(GOSSIP_DURATION).map(Ok)),
+				precommit_timer: Box::new(Delay::new(GOSSIP_DURATION + GOSSIP_DURATION).map(Ok)),
+				incoming: Box::new(incoming),
 				outgoing: Box::pin(outgoing),
 			}
 		}
@@ -235,7 +234,7 @@ pub mod environment {
 			let delay = Duration::from_millis(
 				rand::thread_rng().gen_range(0, COMMIT_DELAY_MILLIS));
 
-			Box::pin(Delay::new(delay).map(Ok))
+			Box::new(Delay::new(delay).map(Ok))
 		}
 
 		fn completed(

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -442,7 +442,7 @@ pub mod report {
 	}
 
 	pub struct VoterState<Id> {
-		//pub background_rounds: HashMap<u64, RoundState<Id>>,
+		pub background_rounds: HashMap<u64, RoundState<Id>>,
 		pub best_round: (u64, RoundState<Id>),
 	}
 }
@@ -478,9 +478,12 @@ impl<H, N, E> VoterState<E::Id> for Arc<RwLock<Inner<H, N, E>>> where
 			}
 		);
 
+		// WIP: query past_rounds and pass in background_rounds
+		let background_rounds = Default::default();
+
 		report::VoterState {
 			best_round,
-			// background_rounds,
+			background_rounds,
 		}
 	}
 }

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -1393,6 +1393,9 @@ mod tests {
 	fn skips_to_latest_round_after_catch_up() {
 		// 3 voters
 		let voters = VoterSet::new((0..3).map(|i| (Id(i), 1u64))).expect("nonempty");
+		let total_weight = voters.total_weight();
+		let threshold_weight = voters.threshold();
+		let voter_ids: HashSet<Id> = (0..3).map(|i| Id(i)).collect();
 
 		let (network, routing_task) = testing::environment::make_network();
 		let mut pool = LocalPool::new();
@@ -1444,9 +1447,12 @@ mod tests {
 			Callback::Blank,
 		));
 
+		let voter_state = unsynced_voter.voter_state();
+		assert_eq!(voter_state.voter_state().background_rounds.get(&5), None);
+
 		// poll until it's caught up.
 		// should skip to round 6
-		pool.run_until(future::poll_fn(move |cx| -> Poll<()> {
+		let output = pool.run_until(future::poll_fn(move |cx| -> Poll<()> {
 			let poll = unsynced_voter.poll_unpin(cx);
 			if unsynced_voter.inner.read().best_round.round_number() == 6 {
 				Poll::Ready(())
@@ -1454,7 +1460,36 @@ mod tests {
 				futures::ready!(poll).unwrap();
 				Poll::Ready(())
 			}
-		}))
+		}));
+
+		assert_eq!(
+			voter_state.voter_state().best_round,
+			(
+				6,
+				report::RoundState::<Id> {
+					total_weight,
+					threshold_weight,
+					prevote_current_weight: VoteWeight(0),
+					prevote_ids: Default::default(),
+					precommit_current_weight: VoteWeight(0),
+					precommit_ids: Default::default(),
+				}
+			)
+		);
+		assert_eq!(
+			voter_state.voter_state().background_rounds.get(&5),
+			Some(&report::RoundState::<Id> {
+				total_weight,
+				threshold_weight,
+				prevote_current_weight: VoteWeight(3),
+				prevote_ids: voter_ids.clone(),
+				precommit_current_weight: VoteWeight(3),
+				precommit_ids: voter_ids,
+			})
+		);
+
+
+		output
 	}
 
 	#[test]

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -423,6 +423,7 @@ fn instantiate_last_round<H, N, E: Environment<H, N>>(
 	}
 }
 
+/// Allows querying the state of the voter.
 pub trait VoterState<Id> {
 	fn voter_state(&self) -> report::VoterState<Id>;
 }
@@ -431,6 +432,7 @@ pub mod report {
 	use std::collections::{HashMap, HashSet};
 	use crate::weights::{VoteWeight, VoterWeight};
 
+	/// Basic data struct for the state of a round.
 	pub struct RoundState<Id> {
 		pub total_weight: VoterWeight,
 		pub threshold_weight: VoterWeight,
@@ -442,6 +444,8 @@ pub mod report {
 		pub precommit_ids: HashSet<Id>,
 	}
 
+	/// Basic data struct for the current state of the voter in a form suitable
+	/// for passing on to other systems.
 	pub struct VoterState<Id> {
 		pub background_rounds: HashMap<u64, RoundState<Id>>,
 		pub best_round: (u64, RoundState<Id>),

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -430,10 +430,12 @@ fn instantiate_last_round<H, N, E: Environment<H, N>>(
 	}
 }
 
-/// Trait for querying the state of the voter. Used by `Voter` to return a queryable object without exposing too may
+/// Trait for querying the state of the voter. Used by `Voter` to return a queryable object 
+/// without exposing too many data types.
 /// data types.
 pub trait VoterState<Id: Eq + std::hash::Hash> {
-	/// Returns a plain data type, `report::VoterState`, describing the current state of the voter relevant to the
+	/// Returns a plain data type, `report::VoterState`, describing the current state 
+	/// of the voter relevant to the voting process.
 	/// voting process.
 	fn voter_state(&self) -> report::VoterState<Id>;
 }
@@ -468,7 +470,7 @@ pub mod report {
 	#[derive(PartialEq, Eq)]
 	#[cfg_attr(test, derive(Debug))]
 	pub struct VoterState<Id: Eq + std::hash::Hash> {
-		/// Voting rounds run in the background.
+		/// Voting rounds running in the background.
 		pub background_rounds: HashMap<u64, RoundState<Id>>,
 		/// The current best voting round.
 		pub best_round: (u64, RoundState<Id>),

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -422,7 +422,7 @@ fn instantiate_last_round<H, N, E: Environment<H, N>>(
 	}
 }
 
-trait VoterState<Id> {
+pub trait VoterState<Id> {
 	fn voter_state(&self) -> report::RoundState<Id>;
 }
 
@@ -503,7 +503,7 @@ impl<'a, H: 'a, N, E: 'a, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, GlobalOu
 	GlobalIn: Stream<Item=Result<CommunicationIn<H, N, E::Signature, E::Id>, E::Error>> + Unpin,
 	GlobalOut: Sink<CommunicationOut<H, N, E::Signature, E::Id>, Error=E::Error> + Unpin,
 {
-	fn voter_state(&self) -> Box<dyn VoterState<E::Id> + 'a> {
+	pub fn voter_state(&self) -> Box<dyn VoterState<E::Id> + 'a> {
 		Box::new(self.inner.clone())
 	}
 }
@@ -606,7 +606,7 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 		while let Poll::Ready(res) = Stream::poll_next(Pin::new(&mut self.finalized_notifications), cx) {
 			let inner = self.inner.clone();
 			let mut inner = inner.write();
-	
+
 			let (f_hash, f_num, round, commit) =
 				res.expect("one sender always kept alive in self.best_round; qed");
 

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -1114,7 +1114,6 @@ mod tests {
 		let num_voters = 10;
 		let voters_online = 7;
 		let voters = VoterSet::new((0..num_voters).map(|i| (Id(i), 1))).expect("nonempty");
-		let voter_ids: HashSet<Id> = (0..voters_online).map(|i| Id(i)).collect();
 
 		let (network, routing_task) = testing::environment::make_network();
 		let mut pool = LocalPool::new();
@@ -1178,31 +1177,18 @@ mod tests {
 		pool.run_until(future::join_all(finalized_streams.into_iter()));
 
 		assert_eq!(
-			voter_state.voter_state(),
-			report::VoterState {
-				background_rounds: vec![(
-					1,
-					report::RoundState::<Id> {
-						total_weight: VoterWeight::new(num_voters.into()).expect("nonzero"),
-						threshold_weight: VoterWeight::new(voters_online.into()).expect("nonzero"),
-						prevote_current_weight: VoteWeight(voters_online.into()),
-						prevote_ids: voter_ids.clone(),
-						precommit_current_weight: VoteWeight(voters_online.into()),
-						precommit_ids: voter_ids,
-					},
-				)].into_iter().collect(),
-				best_round: (
-					2,
-					report::RoundState::<Id> {
-						total_weight: VoterWeight::new(num_voters.into()).expect("nonzero"),
-						threshold_weight: VoterWeight::new(voters_online.into()).expect("nonzero"),
-						prevote_current_weight: VoteWeight(0),
-						prevote_ids: Default::default(),
-						precommit_current_weight: VoteWeight(0),
-						precommit_ids: Default::default(),
-					}
-				),
-			}
+			voter_state.voter_state().best_round,
+			(
+				2,
+				report::RoundState::<Id> {
+					total_weight: VoterWeight::new(num_voters.into()).expect("nonzero"),
+					threshold_weight: VoterWeight::new(voters_online.into()).expect("nonzero"),
+					prevote_current_weight: VoteWeight(0),
+					prevote_ids: Default::default(),
+					precommit_current_weight: VoteWeight(0),
+					precommit_ids: Default::default(),
+				}
+			)
 		);
 	}
 

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -56,11 +56,18 @@ mod voting_round;
 ///
 /// This encapsulates the database and networking layers of the chain.
 pub trait Environment<H: Eq, N: BlockNumberOps>: Chain<H, N> {
+	/// Associated timer for the Environment. See also
+	/// [round_commit_data](trait.Environment.html#tymethod.round_commit_timer).
 	type Timer: Future<Output=Result<(),Self::Error>> + Unpin;
+	/// The associated Id for the Environment.
 	type Id: Ord + Clone + Eq + ::std::fmt::Debug;
+	/// The associated Signature for the Environment.
 	type Signature: Eq + Clone;
+	/// The input stream used to communicate with the outside world.
 	type In: Stream<Item=Result<SignedMessage<H, N, Self::Signature, Self::Id>, Self::Error>> + Unpin;
+	/// The output stream used to communicate with the outside world.
 	type Out: Sink<Message<H, N>, Error=Self::Error> + Unpin;
+	/// The assocated Error type.
 	type Error: From<crate::Error> + ::std::error::Error;
 
 	/// Produce data necessary to start a round of voting. This may also be called
@@ -133,9 +140,9 @@ pub trait Environment<H: Eq, N: BlockNumberOps>: Chain<H, N> {
 	// TODO: make this a future that resolves when it's e.g. written to disk?
 	fn finalize_block(&self, hash: H, number: N, round: u64, commit: Commit<H, N, Self::Signature, Self::Id>) -> Result<(), Self::Error>;
 
-	// Note that an equivocation in prevotes has occurred.s
+	/// Note that an equivocation in prevotes has occurred.
 	fn prevote_equivocation(&self, round: u64, equivocation: Equivocation<Self::Id, Prevote<H, N>, Self::Signature>);
-	// Note that an equivocation in precommits has occurred.
+	/// Note that an equivocation in precommits has occurred.
 	fn precommit_equivocation(&self, round: u64, equivocation: Equivocation<Self::Id, Precommit<H, N>, Self::Signature>);
 }
 
@@ -563,6 +570,7 @@ impl<'a, H: 'a, N, E: 'a, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, GlobalOu
 	GlobalIn: Stream<Item=Result<CommunicationIn<H, N, E::Signature, E::Id>, E::Error>> + Unpin,
 	GlobalOut: Sink<CommunicationOut<H, N, E::Signature, E::Id>, Error=E::Error> + Unpin,
 {
+	/// Returns an object allowing to query the voter state.
 	pub fn voter_state(&self) -> Box<dyn VoterState<E::Id> + 'a + Send + Sync>
 	where
 		<E as Environment<H, N>>::Signature: Send + Sync,

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -463,23 +463,28 @@ impl<H, N, E> VoterState<E::Id> for Arc<RwLock<Inner<H, N, E>>> where
 	<E as Environment<H, N>>::Id: Hash,
 {
 	fn voter_state(&self) -> report::VoterState<E::Id> {
-		let best_round = &self.read().best_round;
-		let _past_rounds = &self.read().past_rounds;
+		let lock = self.read();
 
-		let best_round = (
-			best_round.round_number(),
-			report::RoundState {
-				total_weight: best_round.voters().total_weight(),
-				threshold_weight: best_round.voters().threshold(),
-				prevote_current_weight: best_round.prevote_weight(),
-				prevote_ids: best_round.prevote_ids().collect(),
-				precommit_current_weight: best_round.precommit_weight(),
-				precommit_ids: best_round.precommit_ids().collect(),
-			}
-		);
+		let best_round = {
+			let best_round = &lock.best_round;
+			(
+				best_round.round_number(),
+				report::RoundState {
+					total_weight: best_round.voters().total_weight(),
+					threshold_weight: best_round.voters().threshold(),
+					prevote_current_weight: best_round.prevote_weight(),
+					prevote_ids: best_round.prevote_ids().collect(),
+					precommit_current_weight: best_round.precommit_weight(),
+					precommit_ids: best_round.precommit_ids().collect(),
+				}
+			)
+		};
 
 		// WIP: query past_rounds and pass in background_rounds
-		let background_rounds = Default::default();
+		let background_rounds = {
+			let _past_rounds = &lock.past_rounds;
+			Default::default()
+		};
 
 		report::VoterState {
 			best_round,

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -1314,7 +1314,7 @@ mod tests {
 		// should skip to round 6
 		pool.run_until(future::poll_fn(move |cx| -> Poll<()> {
 			let poll = unsynced_voter.poll_unpin(cx);
-			if unsynced_voter.best_round.round_number() == 6 {
+			if unsynced_voter.inner.read().best_round.round_number() == 6 {
 				Poll::Ready(())
 			} else {
 				futures::ready!(poll).unwrap();
@@ -1453,5 +1453,4 @@ mod tests {
 
 		assert_eq!(outer_env.last_completed_and_concluded(), (2, 1));
 	}
-
 }

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -456,7 +456,7 @@ pub mod report {
 	}
 }
 
-pub struct Inner<H, N, E> where
+struct Inner<H, N, E> where
 	H: Clone + Ord + std::fmt::Debug,
 	N: BlockNumberOps,
 	E: Environment<H, N>,

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -398,7 +398,7 @@ fn instantiate_last_round<H, N, E: Environment<H, N>>(
 	N: Copy + BlockNumberOps + ::std::fmt::Debug,
 {
 	let last_round_tracker = crate::round::Round::new(crate::round::RoundParams {
-		voters: voters,
+		voters,
 		base: last_round_base,
 		round_number: last_round_number,
 	});
@@ -470,11 +470,11 @@ impl<H, N, E> VoterState<E::Id> for Arc<RwLock<Inner<H, N, E>>> where
 			(
 				best_round.round_number(),
 				report::RoundState {
-					total_weight: best_round.voters().total_weight(),
-					threshold_weight: best_round.voters().threshold(),
-					prevote_current_weight: best_round.prevote_weight(),
+					total_weight: best_round.voters().total_weight().get(),
+					threshold_weight: best_round.voters().threshold().get(),
+					prevote_current_weight: best_round.prevote_weight().0,
 					prevote_ids: best_round.prevote_ids().collect(),
-					precommit_current_weight: best_round.precommit_weight(),
+					precommit_current_weight: best_round.precommit_weight().0,
 					precommit_ids: best_round.precommit_ids().collect(),
 				}
 			)

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -429,7 +429,9 @@ pub trait VoterState<Id> {
 
 pub mod report {
 	use std::collections::{HashMap, HashSet};
-	use crate::weights::{VoteWeight, VoterWeight};
+	use crate::{voter::VotingRound, weights::{VoteWeight, VoterWeight}};
+	use crate::BlockNumberOps;
+	use crate::voter::Environment;
 
 	pub struct RoundState<Id> {
 		pub total_weight: VoterWeight,
@@ -440,6 +442,23 @@ pub mod report {
 
 		pub precommit_current_weight: VoteWeight,
 		pub precommit_ids: HashSet<Id>,
+	}
+
+	impl<Id> RoundState<Id> {
+		pub fn from_voting_round<H, N, E>(voting_round: &VotingRound<H, N, E>) -> Self where
+			H: Clone + Ord + std::fmt::Debug,
+			N: Copy + BlockNumberOps,
+			E: Environment<H, N>,
+		{
+			Self {
+				total_weight: voting_round.voters().total_weight(),
+				threshold_weight: voting_round.voters().threshold(),
+				prevote_current_weight: voting_round.prevote_weight(),
+				prevote_ids: voting_round.prevote_ids().collect(),
+				precommit_current_weight: voting_round.precommit_weight(),
+				precommit_ids: voting_round.precommit_ids().collect(),
+			}
+		}
 	}
 
 	pub struct VoterState<Id> {
@@ -465,27 +484,24 @@ impl<H, N, E> VoterState<E::Id> for Arc<RwLock<Inner<H, N, E>>> where
 {
 	fn voter_state(&self) -> report::VoterState<E::Id> {
 		let lock = self.read();
-
 		let best_round = {
 			let best_round = &lock.best_round;
 			(
 				best_round.round_number(),
-				report::RoundState {
-					total_weight: best_round.voters().total_weight(),
-					threshold_weight: best_round.voters().threshold(),
-					prevote_current_weight: best_round.prevote_weight(),
-					prevote_ids: best_round.prevote_ids().collect(),
-					precommit_current_weight: best_round.precommit_weight(),
-					precommit_ids: best_round.precommit_ids().collect(),
-				}
+				report::RoundState::from_voting_round(best_round),
 			)
 		};
 
-		// WIP: query past_rounds and pass in background_rounds
-		let background_rounds = {
-			let _past_rounds = &lock.past_rounds;
-			Default::default()
-		};
+		let background_rounds = lock
+			.past_rounds
+			.voting_rounds()
+			.map(|voting_round| {
+				(
+					voting_round.round_number(),
+					report::RoundState::from_voting_round(voting_round),
+				)
+			})
+			.collect();
 
 		report::VoterState {
 			best_round,

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -61,13 +61,13 @@ pub trait Environment<H: Eq, N: BlockNumberOps>: Chain<H, N> {
 	type Timer: Future<Output=Result<(),Self::Error>> + Unpin;
 	/// The associated Id for the Environment.
 	type Id: Ord + Clone + Eq + ::std::fmt::Debug;
-	/// The associated Signature for the Environment.
+	/// The associated Signature type for the Environment.
 	type Signature: Eq + Clone;
 	/// The input stream used to communicate with the outside world.
 	type In: Stream<Item=Result<SignedMessage<H, N, Self::Signature, Self::Id>, Self::Error>> + Unpin;
 	/// The output stream used to communicate with the outside world.
 	type Out: Sink<Message<H, N>, Error=Self::Error> + Unpin;
-	/// The assocated Error type.
+	/// The associated Error type.
 	type Error: From<crate::Error> + ::std::error::Error;
 
 	/// Produce data necessary to start a round of voting. This may also be called
@@ -430,13 +430,11 @@ fn instantiate_last_round<H, N, E: Environment<H, N>>(
 	}
 }
 
-/// Trait for querying the state of the voter. Used by `Voter` to return a queryable object 
+/// Trait for querying the state of the voter. Used by `Voter` to return a queryable object
 /// without exposing too many data types.
-/// data types.
 pub trait VoterState<Id: Eq + std::hash::Hash> {
-	/// Returns a plain data type, `report::VoterState`, describing the current state 
+	/// Returns a plain data type, `report::VoterState`, describing the current state
 	/// of the voter relevant to the voting process.
-	/// voting process.
 	fn voter_state(&self) -> report::VoterState<Id>;
 }
 

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -1155,41 +1155,27 @@ mod tests {
 		let voter_state = &voter_states[0];
 		voter_states.iter().all(|vs| vs.voter_state() == voter_state.voter_state());
 
+		let expected_round_state = report::RoundState::<Id> {
+			total_weight: VoterWeight::new(num_voters.into()).expect("nonzero"),
+			threshold_weight: VoterWeight::new(voters_online.into()).expect("nonzero"),
+			prevote_current_weight: VoteWeight(0),
+			prevote_ids: Default::default(),
+			precommit_current_weight: VoteWeight(0),
+			precommit_ids: Default::default(),
+		};
+
 		assert_eq!(
 			voter_state.voter_state(),
 			report::VoterState {
 				background_rounds: Default::default(),
-				best_round: (
-					1,
-					report::RoundState::<Id> {
-						total_weight: VoterWeight::new(num_voters.into()).expect("nonzero"),
-						threshold_weight: VoterWeight::new(voters_online.into()).expect("nonzero"),
-						prevote_current_weight: VoteWeight(0),
-						prevote_ids: Default::default(),
-						precommit_current_weight: VoteWeight(0),
-						precommit_ids: Default::default(),
-					}
-				),
+				best_round: (1, expected_round_state.clone()),
 			}
 		);
 
 		pool.spawner().spawn(routing_task.map(|_| ())).unwrap();
 		pool.run_until(future::join_all(finalized_streams.into_iter()));
 
-		assert_eq!(
-			voter_state.voter_state().best_round,
-			(
-				2,
-				report::RoundState::<Id> {
-					total_weight: VoterWeight::new(num_voters.into()).expect("nonzero"),
-					threshold_weight: VoterWeight::new(voters_online.into()).expect("nonzero"),
-					prevote_current_weight: VoteWeight(0),
-					prevote_ids: Default::default(),
-					precommit_current_weight: VoteWeight(0),
-					precommit_ids: Default::default(),
-				}
-			)
-		);
+		assert_eq!(voter_state.voter_state().best_round, (2, expected_round_state.clone()));
 	}
 
 	#[test]

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -36,6 +36,7 @@ use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::hash::Hash;
 
 use crate::round::State as RoundState;
 use crate::{
@@ -423,19 +424,25 @@ fn instantiate_last_round<H, N, E: Environment<H, N>>(
 }
 
 pub trait VoterState<Id> {
-	fn voter_state(&self) -> report::RoundState<Id>;
+	fn voter_state(&self) -> report::VoterState<Id>;
 }
 
-mod report {
+pub mod report {
 	use std::collections::{HashMap, HashSet};
 
 	pub struct RoundState<Id> {
-		pub prevotes: HashSet<Id>,
-		pub precommits: HashSet<Id>,
+		pub total_weight: u64,
+		pub threshold_weight: u64,
+
+		pub prevote_current_weight: u64,
+		pub prevote_ids: HashSet<Id>,
+
+		pub precommit_current_weight: u64,
+		pub precommit_ids: HashSet<Id>,
 	}
 
 	pub struct VoterState<Id> {
-		pub background_rounds: HashMap<u64, RoundState<Id>>,
+		//pub background_rounds: HashMap<u64, RoundState<Id>>,
 		pub best_round: (u64, RoundState<Id>),
 	}
 }
@@ -453,9 +460,28 @@ impl<H, N, E> VoterState<E::Id> for Arc<RwLock<Inner<H, N, E>>> where
 	H: Clone + Eq + Ord + std::fmt::Debug,
 	N: BlockNumberOps,
 	E: Environment<H, N>,
+	<E as Environment<H, N>>::Id: Hash,
 {
-	fn voter_state(&self) -> report::RoundState<E::Id> {
-		unimplemented!()
+	fn voter_state(&self) -> report::VoterState<E::Id> {
+		let best_round = &self.read().best_round;
+		let _past_rounds = &self.read().past_rounds;
+
+		let best_round = (
+			best_round.round_number(),
+			report::RoundState {
+				total_weight: best_round.voters().total_weight(),
+				threshold_weight: best_round.voters().threshold(),
+				prevote_current_weight: best_round.prevote_weight(),
+				prevote_ids: best_round.prevote_ids().collect(),
+				precommit_current_weight: best_round.precommit_weight(),
+				precommit_ids: best_round.precommit_ids().collect(),
+			}
+		);
+
+		report::VoterState {
+			best_round,
+			// background_rounds,
+		}
 	}
 }
 
@@ -506,7 +532,7 @@ impl<'a, H: 'a, N, E: 'a, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, GlobalOu
 	pub fn voter_state(&self) -> Box<dyn VoterState<E::Id> + 'a + Send + Sync>
 	where
 		<E as Environment<H, N>>::Signature: Send + Sync,
-		<E as Environment<H, N>>::Id: Send + Sync,
+		<E as Environment<H, N>>::Id: Hash + Send + Sync,
 		<E as Environment<H, N>>::Timer: Send + Sync,
 		<E as Environment<H, N>>::Out: Send + Sync,
 		<E as Environment<H, N>>::In: Send + Sync,

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -422,15 +422,21 @@ fn instantiate_last_round<H, N, E: Environment<H, N>>(
 	}
 }
 
-trait VoterState {
-	fn voter_state(&self) -> (u32, u32, u32, u32);
+trait VoterState<Id> {
+	fn voter_state(&self) -> report::RoundState<Id>;
 }
 
-struct NullVoterState;
+mod report {
+	use std::collections::{HashMap, HashSet};
 
-impl VoterState for NullVoterState {
-	fn voter_state(&self) -> (u32, u32, u32, u32) {
-		(0, 0 ,0 ,0)
+	pub struct RoundState<Id> {
+		pub prevotes: HashSet<Id>,
+		pub precommits: HashSet<Id>,
+	}
+
+	pub struct VoterState<Id> {
+		pub background_rounds: HashMap<u64, RoundState<Id>>,
+		pub best_round: (u64, RoundState<Id>),
 	}
 }
 
@@ -443,12 +449,12 @@ pub struct Inner<H, N, E> where
 	past_rounds: PastRounds<H, N, E>,
 }
 
-impl<H, N, E> VoterState for Arc<RwLock<Inner<H, N, E>>> where
+impl<H, N, E> VoterState<E::Id> for Arc<RwLock<Inner<H, N, E>>> where
 	H: Clone + Eq + Ord + std::fmt::Debug,
 	N: BlockNumberOps,
 	E: Environment<H, N>,
 {
-	fn voter_state(&self) -> (u32, u32, u32, u32) {
+	fn voter_state(&self) -> report::RoundState<E::Id> {
 		unimplemented!()
 	}
 }
@@ -497,7 +503,7 @@ impl<'a, H: 'a, N, E: 'a, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, GlobalOu
 	GlobalIn: Stream<Item=Result<CommunicationIn<H, N, E::Signature, E::Id>, E::Error>> + Unpin,
 	GlobalOut: Sink<CommunicationOut<H, N, E::Signature, E::Id>, Error=E::Error> + Unpin,
 {
-	fn voter_state(&self) -> Box<dyn VoterState + 'a> {
+	fn voter_state(&self) -> Box<dyn VoterState<E::Id> + 'a> {
 		Box::new(self.inner.clone())
 	}
 }

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -497,13 +497,20 @@ pub struct Voter<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> where
 }
 
 impl<'a, H: 'a, N, E: 'a, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, GlobalOut> where
-	H: Clone + Ord + ::std::fmt::Debug,
-	N: BlockNumberOps,
-	E: Environment<H, N>,
+	H: Clone + Ord + ::std::fmt::Debug + Sync + Send,
+	N: BlockNumberOps + Sync + Send,
+	E: Environment<H, N> + Sync + Send,
 	GlobalIn: Stream<Item=Result<CommunicationIn<H, N, E::Signature, E::Id>, E::Error>> + Unpin,
 	GlobalOut: Sink<CommunicationOut<H, N, E::Signature, E::Id>, Error=E::Error> + Unpin,
 {
-	pub fn voter_state(&self) -> Box<dyn VoterState<E::Id> + 'a> {
+	pub fn voter_state(&self) -> Box<dyn VoterState<E::Id> + 'a + Send + Sync>
+	where
+		<E as Environment<H, N>>::Signature: Send + Sync,
+		<E as Environment<H, N>>::Id: Send + Sync,
+		<E as Environment<H, N>>::Timer: Send + Sync,
+		<E as Environment<H, N>>::Out: Send + Sync,
+		<E as Environment<H, N>>::In: Send + Sync,
+	{
 		Box::new(self.inner.clone())
 	}
 }

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -816,8 +816,8 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 			if !should_start_next { return Poll::Pending }
 
 			trace!(target: "afg", "Best round at {} has become completable. Starting new best round at {}",
-				   inner.best_round.round_number(),
-				   inner.best_round.round_number() + 1,
+				inner.best_round.round_number(),
+				inner.best_round.round_number() + 1,
 			);
 		}
 
@@ -1462,6 +1462,7 @@ mod tests {
 				}
 			)
 		);
+
 		assert_eq!(
 			voter_state.voter_state().background_rounds.get(&5),
 			Some(&report::RoundState::<Id> {
@@ -1473,7 +1474,6 @@ mod tests {
 				precommit_ids: voter_ids,
 			})
 		);
-
 
 		output
 	}

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -423,11 +423,15 @@ fn instantiate_last_round<H, N, E: Environment<H, N>>(
 	}
 }
 
-/// Allows querying the state of the voter.
+/// Trait for querying the state of the voter. Used by `Voter` to return a queryable object without exposing too may
+/// data types.
 pub trait VoterState<Id: Eq + std::hash::Hash> {
+	/// Returns a plain data type, `report::VoterState`, describing the current state of the voter relevant to the
+	/// voting process.
 	fn voter_state(&self) -> report::VoterState<Id>;
 }
 
+/// Contains a number of data transfer objects for reporting data to the outside world.
 pub mod report {
 	use std::collections::{HashMap, HashSet};
 	use crate::weights::{VoteWeight, VoterWeight};
@@ -436,13 +440,19 @@ pub mod report {
 	#[derive(PartialEq, Eq, Clone)]
 	#[cfg_attr(test, derive(Debug))]
 	pub struct RoundState<Id: Eq + std::hash::Hash> {
+		/// Total weight of all votes.
 		pub total_weight: VoterWeight,
+		/// The threshold voter weight.
 		pub threshold_weight: VoterWeight,
 
+		/// Current weight of the prevotes.
 		pub prevote_current_weight: VoteWeight,
+		/// The identities of nodes that have cast prevotes so far.
 		pub prevote_ids: HashSet<Id>,
 
+		/// Current weight of the precommits.
 		pub precommit_current_weight: VoteWeight,
+		/// The identities of nodes that have cast precommits so far.
 		pub precommit_ids: HashSet<Id>,
 	}
 
@@ -451,11 +461,14 @@ pub mod report {
 	#[derive(PartialEq, Eq)]
 	#[cfg_attr(test, derive(Debug))]
 	pub struct VoterState<Id: Eq + std::hash::Hash> {
+		/// Voting rounds run in the background.
 		pub background_rounds: HashMap<u64, RoundState<Id>>,
+		/// The current best voting round.
 		pub best_round: (u64, RoundState<Id>),
 	}
 }
 
+// Collect the voter state that we want to wrap in an `Arc<RwLock>` suitable for sharing.
 struct Inner<H, N, E> where
 	H: Clone + Ord + std::fmt::Debug,
 	N: BlockNumberOps,

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -429,15 +429,16 @@ pub trait VoterState<Id> {
 
 pub mod report {
 	use std::collections::{HashMap, HashSet};
+	use crate::weights::{VoteWeight, VoterWeight};
 
 	pub struct RoundState<Id> {
-		pub total_weight: u64,
-		pub threshold_weight: u64,
+		pub total_weight: VoterWeight,
+		pub threshold_weight: VoterWeight,
 
-		pub prevote_current_weight: u64,
+		pub prevote_current_weight: VoteWeight,
 		pub prevote_ids: HashSet<Id>,
 
-		pub precommit_current_weight: u64,
+		pub precommit_current_weight: VoteWeight,
 		pub precommit_ids: HashSet<Id>,
 	}
 
@@ -470,11 +471,11 @@ impl<H, N, E> VoterState<E::Id> for Arc<RwLock<Inner<H, N, E>>> where
 			(
 				best_round.round_number(),
 				report::RoundState {
-					total_weight: best_round.voters().total_weight().get(),
-					threshold_weight: best_round.voters().threshold().get(),
-					prevote_current_weight: best_round.prevote_weight().0,
+					total_weight: best_round.voters().total_weight(),
+					threshold_weight: best_round.voters().threshold(),
+					prevote_current_weight: best_round.prevote_weight(),
 					prevote_ids: best_round.prevote_ids().collect(),
-					precommit_current_weight: best_round.precommit_weight().0,
+					precommit_current_weight: best_round.precommit_weight(),
 					precommit_ids: best_round.precommit_ids().collect(),
 				}
 			)

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -420,6 +420,18 @@ fn instantiate_last_round<H, N, E: Environment<H, N>>(
 	}
 }
 
+// NOTE to jon: The interface we expose no longer needs to be typed on Environment.
+trait VoterState {
+	fn voter_state(&self) -> (u32, u32, u32, u32);
+}
+
+struct NullVoterState;
+impl VoterState for NullVoterState {
+	fn voter_state(&self) -> (u32, u32, u32, u32) {
+		(0, 0 ,0 ,0)
+	}
+}
+
 /// A future that maintains and multiplexes between different rounds,
 /// and caches votes.
 ///
@@ -536,6 +548,10 @@ impl<H, N, E: Environment<H, N>, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, G
 			global_in,
 			global_out: Buffered::new(global_out),
 		}
+	}
+
+	fn voter_state(&self) -> Box<dyn VoterState> {
+		Box::new(NullVoterState)
 	}
 
 	fn prune_background_rounds(&mut self, cx: &mut Context) -> Result<(), E::Error> {

--- a/src/voter/past_rounds.rs
+++ b/src/voter/past_rounds.rs
@@ -290,6 +290,7 @@ impl<H, N, E: Environment<H, N>> PastRounds<H, N, E> where
 		}
 	}
 
+	/// Get the underlying `VotingRound` items that are being run in the background.
 	pub(super) fn voting_rounds(&self) -> impl Iterator<Item = &VotingRound<H, N, E>> {
 		self.past_rounds
 			.iter()

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -285,6 +285,26 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		self.votes.finalized()
 	}
 
+	/// Get the current weight of the prevotes
+	pub(super) fn prevote_weight(&self) -> u64 {
+		self.votes.prevote_participation().0
+	}
+
+	/// Get the current weight of the precommits
+	pub(super) fn precommit_weight(&self) -> u64 {
+		self.votes.precommit_participation().0
+	}
+
+	/// Get the Ids of the prevotes
+	pub(super) fn prevote_ids(&self) -> impl Iterator<Item = E::Id> {
+		self.votes.prevotes().into_iter().map(|pv| pv.0)
+	}
+
+	/// Get the Ids of the precommits
+	pub(super) fn precommit_ids(&self) -> impl Iterator<Item = E::Id> {
+		self.votes.precommits().into_iter().map(|pv| pv.0)
+	}
+
 	/// Check a commit. If it's valid, import all the votes into the round as well.
 	/// Returns the finalized base if it checks out.
 	pub(super) fn check_and_import_from_commit(

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -29,7 +29,7 @@ use crate::round::{Round, State as RoundState};
 use crate::{
 	Commit, Message, Prevote, Precommit, PrimaryPropose, SignedMessage,
 	SignedPrecommit, BlockNumberOps, validate_commit, ImportResult,
-	HistoricalVotes,
+	HistoricalVotes, weights::VoteWeight,
 };
 use crate::voter_set::VoterSet;
 use super::{Environment, Buffered, FinalizedNotification};
@@ -286,12 +286,12 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 	}
 
 	/// Get the current weight of the prevotes
-	pub(super) fn prevote_weight(&self) -> u64 {
+	pub(super) fn prevote_weight(&self) -> VoteWeight {
 		self.votes.prevote_participation().0
 	}
 
 	/// Get the current weight of the precommits
-	pub(super) fn precommit_weight(&self) -> u64 {
+	pub(super) fn precommit_weight(&self) -> VoteWeight {
 		self.votes.precommit_participation().0
 	}
 

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -285,22 +285,22 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		self.votes.finalized()
 	}
 
-	/// Get the current weight of the prevotes
+	/// Get the current total weight of prevotes.
 	pub(super) fn prevote_weight(&self) -> VoteWeight {
 		self.votes.prevote_participation().0
 	}
 
-	/// Get the current weight of the precommits
+	/// Get the current total weight of precommits.
 	pub(super) fn precommit_weight(&self) -> VoteWeight {
 		self.votes.precommit_participation().0
 	}
 
-	/// Get the Ids of the prevotes
+	/// Get the Ids of the prevoters.
 	pub(super) fn prevote_ids(&self) -> impl Iterator<Item = E::Id> {
 		self.votes.prevotes().into_iter().map(|pv| pv.0)
 	}
 
-	/// Get the Ids of the precommits
+	/// Get the Ids of the precommitters.
 	pub(super) fn precommit_ids(&self) -> impl Iterator<Item = E::Id> {
 		self.votes.precommits().into_iter().map(|pv| pv.0)
 	}

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -90,7 +90,7 @@ impl VoterWeight {
 		NonZeroU64::new(weight).map(Self)
 	}
 
-	pub fn get(&self) -> u64 {
+	pub fn get(self) -> u64 {
 		self.0.get()
 	}
 }


### PR DESCRIPTION
Implement #55 and support https://github.com/paritytech/substrate/issues/4921 / https://github.com/paritytech/substrate/pull/5375

Expose voter state to the outside world. Useful for querying diagnostics

Left to do: 
- [x] Populate `background_rounds` https://github.com/paritytech/finality-grandpa/pull/114/files#diff-7dbd927baa51274d73fc2a7cb663e166R484