### PR TITLE
Fix background round pruning

### DIFF
--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -1421,7 +1421,7 @@ mod tests {
 		pool.spawner().spawn(routing_task.map(|_| ())).unwrap();
 
 		// initialize unsynced voter at round 0
-		let mut unsynced_voter = {
+		let (env, unsynced_voter) = {
 			let local_id = Id(4);
 
 			let env = Arc::new(Environment::new(network.clone(), local_id));
@@ -1430,7 +1430,7 @@ mod tests {
 				chain.last_finalized()
 			});
 
-			Voter::new(
+			let voter = Voter::new(
 				env.clone(),
 				voters.clone(),
 				network.make_global_comms(),
@@ -1438,7 +1438,9 @@ mod tests {
 				Vec::new(),
 				last_finalized,
 				last_finalized,
-			)
+			);
+
+			(env, voter)
 		};
 
 		let pv = |id| crate::SignedPrevote {
@@ -1468,17 +1470,23 @@ mod tests {
 		let voter_state = unsynced_voter.voter_state();
 		assert_eq!(voter_state.get().background_rounds.get(&5), None);
 
-		// poll until it's caught up.
-		// should skip to round 6
-		let output = pool.run_until(future::poll_fn(move |cx| -> Poll<()> {
-			let poll = unsynced_voter.poll_unpin(cx);
-			if unsynced_voter.inner.read().best_round.round_number() == 6 {
+		// spawn the voter in the background
+		pool.spawner().spawn(unsynced_voter.map(|_| ())).unwrap();
+
+		// wait until it's caught up, it should skip to round 6 and send a
+		// finality notification for the block that was finalized by catching
+		// up.
+		let caught_up = future::poll_fn(|_| {
+			if voter_state.get().best_round.0 == 6 {
 				Poll::Ready(())
 			} else {
-				futures::ready!(poll).unwrap();
-				Poll::Ready(())
+				Poll::Pending
 			}
-		}));
+		});
+
+		let finalized = env.finalized_stream().take(1).into_future();
+
+		pool.run_until(caught_up.then(|_| finalized.map(|_| ())));
 
 		assert_eq!(
 			voter_state.get().best_round,
@@ -1506,8 +1514,6 @@ mod tests {
 				precommit_ids: voter_ids,
 			})
 		);
-
-		output
 	}
 
 	#[test]

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -658,6 +658,8 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 
 		if new_state.completable && (state_changed || !sent_finality_notifications) {
 			let precommitted = matches!(self.state, Some(State::Precommitted));
+			// we only cast votes when we have access to the previous round state,
+			// which won't be the case whenever we catch up to a later round.
 			let cant_vote = self.last_round_state.is_none();
 
 			if precommitted || cant_vote {


### PR DESCRIPTION
Whenever we catch-up to a later round we instantiate the caught up round as completed and keep running it in the background. This particular round instance won't have access to the previous round state (since we caught up) and therefore won't be able to vote. Whenever we finalize something in a round we send a notification to the voter but this code assumes that the round will be executed to its terminal state (precommitted) until any finality notification is sent. A consequence of not sending any finality notifications is also that we won't be pruning any background rounds based on this.

In Substrate I tracked a background round leak down to this issue. If the node can't keep up with the latest round (e.g. if it's not an authority gossip data for the latest round takes too long to reach it) and it's keeping up with the latest round through catch up messages then these background rounds would never be pruned.

Additionally I also made it so that when finalizing something through a commit we also prune the background rounds.