### PR TITLE
Rewrite with async/await

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rand = {version = "0.6.0", optional = true }
 either = { version = "1.5.3", default-features = false }
 
 [dev-dependencies]
+futures = { version = "0.3.7", default-features = false, features = [ "async-await", "thread-pool" ] }
 rand = "0.7.0"
 quickcheck = "0.9"
 parking_lot = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1.36"
+async-rwlock = { version = "1.3.0", optional = true }
 futures = { version = "0.3.1", default-features = false }
 futures-timer = { version = "2.0.2", optional = true }
 log = { version = "0.4", optional = true }
-parking_lot = { version = "0.9", optional = true }
 parity-scale-codec = { version = "1.0.3", optional = true, default-features = false, features = ["derive"] }
 num = { package = "num-traits", version = "0.2", default-features = false }
 rand = {version = "0.6.0", optional = true }
@@ -21,10 +21,12 @@ either = { version = "1.5.3", default-features = false }
 [dev-dependencies]
 rand = "0.7.0"
 quickcheck = "0.9"
+parking_lot = "0.9"
+
 
 [features]
 default = ["std"]
-std = ["parity-scale-codec/std", "num/std", "parking_lot", "log", "futures-timer", "futures/executor"]
+std = ["parity-scale-codec/std", "num/std", "async-rwlock", "log", "futures-timer", "futures/executor"]
 derive-codec = ["parity-scale-codec"]
 test-helpers = ["fuzz-helpers", "rand", "std"]
 fuzz-helpers = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rand = "0.7.0"
 quickcheck = "0.9"
 parking_lot = "0.9"
 async-std = { version = "1.6.5", features = ["unstable"] }
+env_logger = "0.8"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/paritytech/finality-grandpa"
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1.36"
 futures = { version = "0.3.1", default-features = false }
 futures-timer = { version = "2.0.2", optional = true }
 log = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.36"
 async-rwlock = { version = "1.3.0", optional = true }
-futures = { version = "0.3.1", default-features = false }
+futures = { version = "0.3.7", default-features = false, features = [ "async-await" ] }
 futures-timer = { version = "2.0.2", optional = true }
 log = { version = "0.4", optional = true }
 parity-scale-codec = { version = "1.0.3", optional = true, default-features = false, features = ["derive"] }
@@ -22,11 +22,20 @@ either = { version = "1.5.3", default-features = false }
 rand = "0.7.0"
 quickcheck = "0.9"
 parking_lot = "0.9"
+async-std = { version = "1.6.5", features = ["unstable"] }
 
 
 [features]
 default = ["std"]
-std = ["parity-scale-codec/std", "num/std", "async-rwlock", "log", "futures-timer", "futures/executor"]
+std = [
+	"parity-scale-codec/std",
+	"num/std",
+	"async-rwlock",
+	"log",
+	"futures-timer",
+	"futures/executor",
+	"futures/async-await",
+]
 derive-codec = ["parity-scale-codec"]
 test-helpers = ["fuzz-helpers", "rand", "std"]
 fuzz-helpers = []

--- a/src/bridge_state.rs
+++ b/src/bridge_state.rs
@@ -84,8 +84,8 @@ mod tests {
 		};
 
 		let (prior, latter) = bridge_state(initial);
-		let waits_for_finality = ::futures::future::poll_fn(move |cx| -> Poll<()> {
-			if latter.get(cx).finalized.is_some() {
+		let waits_for_finality = ::futures::future::poll_fn(move |_| -> Poll<()> {
+			if latter.get().finalized.is_some() {
 				Poll::Ready(())
 			} else {
 				Poll::Pending

--- a/src/bridge_state.rs
+++ b/src/bridge_state.rs
@@ -18,7 +18,6 @@ use crate::round::State as RoundState;
 use futures::task;
 use parking_lot::{RwLock, RwLockReadGuard};
 use std::sync::Arc;
-use std::task::Context;
 
 // round state bridged across rounds.
 struct Bridged<H, N> {
@@ -51,8 +50,7 @@ pub(crate) struct LatterView<H, N>(Arc<Bridged<H, N>>);
 
 impl<H, N> LatterView<H, N> {
 	/// Fetch a handle to the last round-state.
-	pub(crate) fn get(&self, cx: &mut Context) -> RwLockReadGuard<RoundState<H, N>> {
-		self.0.waker.register(cx.waker());
+	pub(crate) fn get(&self) -> RwLockReadGuard<RoundState<H, N>> {
 		self.0.inner.read()
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //!
 //! Equivocation detection and vote-set management is done in the `round` module.
 //! The work for actually casting votes is done in the `voter` module.
+#![recursion_limit="1024"]
 
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/round.rs
+++ b/src/round.rs
@@ -710,68 +710,68 @@ mod tests {
 	#[test]
 	fn estimate_is_valid() {
 		let mut chain = DummyChain::new();
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C", "D", "E", "F"]);
-		chain.push_blocks("E", &["EA", "EB", "EC", "ED"]);
-		chain.push_blocks("F", &["FA", "FB", "FC"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string(), "D".to_string(), "E".to_string(), "F".to_string()]);
+		chain.push_blocks("E".to_string(), &["EA".to_string(), "EB".to_string(), "EC".to_string(), "ED".to_string()]);
+		chain.push_blocks("F".to_string(), &["FA".to_string(), "FB".to_string(), "FC".to_string()]);
 
 		let mut round = Round::new(RoundParams {
 			round_number: 1,
 			voters: voters(),
-			base: ("C", 4),
+			base: ("C".to_string(), 4),
 		});
 
 		round.import_prevote(
 			&chain,
-			Prevote::new("FC", 10),
+			Prevote::new("FC".to_string(), 10),
 			"Alice",
 			Signature("Alice"),
 		).unwrap();
 
 		round.import_prevote(
 			&chain,
-			Prevote::new("ED", 10),
+			Prevote::new("ED".to_string(), 10),
 			"Bob",
 			Signature("Bob"),
 		).unwrap();
 
-		assert_eq!(round.prevote_ghost, Some(("E", 6)));
-		assert_eq!(round.estimate(), Some(&("E", 6)));
+		assert_eq!(round.prevote_ghost, Some(("E".to_string(), 6)));
+		assert_eq!(round.estimate(), Some(&("E".to_string(), 6)));
 		assert!(!round.completable());
 
 		round.import_prevote(
 			&chain,
-			Prevote::new("F", 7),
+			Prevote::new("F".to_string(), 7),
 			"Eve",
 			Signature("Eve"),
 		).unwrap();
 
-		assert_eq!(round.prevote_ghost, Some(("E", 6)));
-		assert_eq!(round.estimate(), Some(&("E", 6)));
+		assert_eq!(round.prevote_ghost, Some(("E".to_string(), 6)));
+		assert_eq!(round.estimate(), Some(&("E".to_string(), 6)));
 	}
 
 	#[test]
 	fn finalization() {
 		let mut chain = DummyChain::new();
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C", "D", "E", "F"]);
-		chain.push_blocks("E", &["EA", "EB", "EC", "ED"]);
-		chain.push_blocks("F", &["FA", "FB", "FC"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string(), "D".to_string(), "E".to_string(), "F".to_string()]);
+		chain.push_blocks("E".to_string(), &["EA".to_string(), "EB".to_string(), "EC".to_string(), "ED".to_string()]);
+		chain.push_blocks("F".to_string(), &["FA".to_string(), "FB".to_string(), "FC".to_string()]);
 
 		let mut round = Round::new(RoundParams {
 			round_number: 1,
 			voters: voters(),
-			base: ("C", 4),
+			base: ("C".to_string(), 4),
 		});
 
 		round.import_precommit(
 			&chain,
-			Precommit::new("FC", 10),
+			Precommit::new("FC".to_string(), 10),
 			"Alice",
 			Signature("Alice"),
 		).unwrap();
 
 		round.import_precommit(
 			&chain,
-			Precommit::new("ED", 10),
+			Precommit::new("ED".to_string(), 10),
 			"Bob",
 			Signature("Bob"),
 		).unwrap();
@@ -782,55 +782,55 @@ mod tests {
 		{
 			round.import_prevote(
 				&chain,
-				Prevote::new("FC", 10),
+				Prevote::new("FC".to_string(), 10),
 				"Alice",
 				Signature("Alice"),
 			).unwrap();
 
 			round.import_prevote(
 				&chain,
-				Prevote::new("ED", 10),
+				Prevote::new("ED".to_string(), 10),
 				"Bob",
 				Signature("Bob"),
 			).unwrap();
 
 			round.import_prevote(
 				&chain,
-				Prevote::new("EA", 7),
+				Prevote::new("EA".to_string(), 7),
 				"Eve",
 				Signature("Eve"),
 			).unwrap();
 
-			assert_eq!(round.finalized, Some(("E", 6)));
+			assert_eq!(round.finalized, Some(("E".to_string(), 6)));
 		}
 
 		round.import_precommit(
 			&chain,
-			Precommit::new("EA", 7),
+			Precommit::new("EA".to_string(), 7),
 			"Eve",
 			Signature("Eve"),
 		).unwrap();
 
-		assert_eq!(round.finalized, Some(("EA", 7)));
+		assert_eq!(round.finalized, Some(("EA".to_string(), 7)));
 	}
 
 	#[test]
 	fn equivocate_does_not_double_count() {
 		let mut chain = DummyChain::new();
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C", "D", "E", "F"]);
-		chain.push_blocks("E", &["EA", "EB", "EC", "ED"]);
-		chain.push_blocks("F", &["FA", "FB", "FC"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string(), "D".to_string(), "E".to_string(), "F".to_string()]);
+		chain.push_blocks("E".to_string(), &["EA".to_string(), "EB".to_string(), "EC".to_string(), "ED".to_string()]);
+		chain.push_blocks("F".to_string(), &["FA".to_string(), "FB".to_string(), "FC".to_string()]);
 
 		let mut round = Round::new(RoundParams {
 			round_number: 1,
 			voters: voters(),
-			base: ("C", 4),
+			base: ("C".to_string(), 4),
 		});
 
 		// first prevote by eve
 		assert!(round.import_prevote(
 			&chain,
-			Prevote::new("FC", 10),
+			Prevote::new("FC".to_string(), 10),
 			"Eve", // 3 on F, E
 			Signature("Eve-1"),
 		).unwrap().equivocation.is_none());
@@ -841,7 +841,7 @@ mod tests {
 		// second prevote by eve: comes with equivocation proof
 		assert!(round.import_prevote(
 			&chain,
-			Prevote::new("ED", 10),
+			Prevote::new("ED".to_string(), 10),
 			"Eve", // still 3 on E
 			Signature("Eve-2"),
 		).unwrap().equivocation.is_some());
@@ -849,7 +849,7 @@ mod tests {
 		// third prevote: returns nothing.
 		assert!(round.import_prevote(
 			&chain,
-			Prevote::new("F", 7),
+			Prevote::new("F".to_string(), 7),
 			"Eve", // still 3 on F and E
 			Signature("Eve-2"),
 		).unwrap().equivocation.is_none());
@@ -860,30 +860,30 @@ mod tests {
 
 		assert!(round.import_prevote(
 			&chain,
-			Prevote::new("FA", 8),
+			Prevote::new("FA".to_string(), 8),
 			"Bob", // add 7 to FA and you get FA.
 			Signature("Bob-1"),
 		).unwrap().equivocation.is_none());
 
-		assert_eq!(round.prevote_ghost, Some(("FA", 8)));
+		assert_eq!(round.prevote_ghost, Some(("FA".to_string(), 8)));
 	}
 
 	#[test]
 	fn historical_votes_works() {
 		let mut chain = DummyChain::new();
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C", "D", "E", "F"]);
-		chain.push_blocks("E", &["EA", "EB", "EC", "ED"]);
-		chain.push_blocks("F", &["FA", "FB", "FC"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string(), "D".to_string(), "E".to_string(), "F".to_string()]);
+		chain.push_blocks("E".to_string(), &["EA".to_string(), "EB".to_string(), "EC".to_string(), "ED".to_string()]);
+		chain.push_blocks("F".to_string(), &["FA".to_string(), "FB".to_string(), "FC".to_string()]);
 
 		let mut round = Round::new(RoundParams {
 			round_number: 1,
 			voters: voters(),
-			base: ("C", 4),
+			base: ("C".to_string(), 4),
 		});
 
 		round.import_prevote(
 			&chain,
-			Prevote::new("FC", 10),
+			Prevote::new("FC".to_string(), 10),
 			"Alice",
 			Signature("Alice"),
 		).unwrap();
@@ -892,21 +892,21 @@ mod tests {
 
 		round.import_prevote(
 			&chain,
-			Prevote::new("EA", 7),
+			Prevote::new("EA".to_string(), 7),
 			"Eve",
 			Signature("Eve"),
 		).unwrap();
 
 		round.import_precommit(
 			&chain,
-			Precommit::new("EA", 7),
+			Precommit::new("EA".to_string(), 7),
 			"Eve",
 			Signature("Eve"),
 		).unwrap();
 
 		round.import_prevote(
 			&chain,
-			Prevote::new("EC", 10),
+			Prevote::new("EC".to_string(), 10),
 			"Alice",
 			Signature("Alice"),
 		).unwrap();
@@ -917,28 +917,28 @@ mod tests {
 			vec![
 				SignedMessage {
 					message: Message::Prevote(
-						Prevote { target_hash: "FC", target_number: 10 }
+						Prevote { target_hash: "FC".to_string(), target_number: 10 }
 					),
 					signature: Signature("Alice"),
 					id: "Alice"
 				},
 				SignedMessage {
 					message: Message::Prevote(
-						Prevote { target_hash: "EA", target_number: 7 }
+						Prevote { target_hash: "EA".to_string(), target_number: 7 }
 					),
 					signature: Signature("Eve"),
 					id: "Eve"
 				},
 				SignedMessage {
 					message: Message::Precommit(
-						Precommit { target_hash: "EA", target_number: 7 }
+						Precommit { target_hash: "EA".to_string(), target_number: 7 }
 					),
 					signature: Signature("Eve"),
 					id: "Eve"
 				},
 				SignedMessage {
 					message: Message::Prevote(
-						Prevote { target_hash: "EC", target_number: 10 }
+						Prevote { target_hash: "EC".to_string(), target_number: 10 }
 					),
 					signature: Signature("Alice"),
 					id: "Alice"

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -135,6 +135,7 @@ pub mod environment {
 		Chain, Commit, Equivocation, Error, HistoricalVotes, Message, Precommit, Prevote,
 		PrimaryPropose, SignedMessage,
 	};
+	use async_trait::async_trait;
 	use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
 	use futures::prelude::*;
 	use futures_timer::Delay;
@@ -198,6 +199,7 @@ pub mod environment {
 		}
 	}
 
+	#[async_trait]
 	impl crate::voter::Environment<&'static str, u32> for Environment {
 		type Timer = Box<dyn Future<Output = Result<(), Error>> + Unpin + Send + Sync>;
 		type Id = Id;
@@ -213,7 +215,7 @@ pub mod environment {
 			Pin<Box<dyn Sink<Message<&'static str, u32>, Error = Error> + Send + Sync + 'static>>;
 		type Error = Error;
 
-		fn round_data(&self, round: u64) -> RoundData<Self::Id, Self::Timer, Self::In, Self::Out> {
+		async fn round_data(&self, round: u64) -> RoundData<Self::Id, Self::Timer, Self::In, Self::Out> {
 			const GOSSIP_DURATION: Duration = Duration::from_millis(500);
 
 			let (incoming, outgoing) = self.network.make_round_comms(round, self.local_id);

--- a/src/vote_graph.rs
+++ b/src/vote_graph.rs
@@ -567,68 +567,68 @@ mod tests {
 	#[test]
 	fn graph_fork_not_at_node() {
 		let mut chain = DummyChain::new();
-		let mut tracker = VoteGraph::new(GENESIS_HASH, 1, 0u32);
+		let mut tracker = VoteGraph::new(GENESIS_HASH.into(), 1, 0u32);
 
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C"]);
-		chain.push_blocks("C", &["D1", "E1", "F1"]);
-		chain.push_blocks("C", &["D2", "E2", "F2"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string()]);
+		chain.push_blocks("C".into(), &["D1".to_string(), "E1".to_string(), "F1".to_string()]);
+		chain.push_blocks("C".into(), &["D2".to_string(), "E2".to_string(), "F2".to_string()]);
 
-		tracker.insert("A", 2, 100, &chain).unwrap();
-		tracker.insert("E1", 6, 100, &chain).unwrap();
-		tracker.insert("F2", 7, 100, &chain).unwrap();
+		tracker.insert("A".to_string(), 2, 100, &chain).unwrap();
+		tracker.insert("E1".to_string(), 6, 100, &chain).unwrap();
+		tracker.insert("F2".to_string(), 7, 100, &chain).unwrap();
 
-		assert!(tracker.heads.contains("E1"));
-		assert!(tracker.heads.contains("F2"));
-		assert!(!tracker.heads.contains("A"));
+		assert!(tracker.heads.contains(&"E1".to_string()));
+		assert!(tracker.heads.contains(&"F2".to_string()));
+		assert!(!tracker.heads.contains(&"A".to_string()));
 
-		let a_entry = tracker.entries.get("A").unwrap();
-		assert_eq!(a_entry.descendents, vec!["E1", "F2"]);
+		let a_entry = tracker.entries.get(&"A".to_string()).unwrap();
+		assert_eq!(a_entry.descendents, vec!["E1".to_string(), "F2".to_string()]);
 		assert_eq!(a_entry.cumulative_vote, 300);
 
-		let e_entry = tracker.entries.get("E1").unwrap();
-		assert_eq!(e_entry.ancestor_node().unwrap(), "A");
+		let e_entry = tracker.entries.get(&"E1".to_string()).unwrap();
+		assert_eq!(e_entry.ancestor_node().unwrap(), "A".to_string());
 		assert_eq!(e_entry.cumulative_vote, 100);
 
-		let f_entry = tracker.entries.get("F2").unwrap();
-		assert_eq!(f_entry.ancestor_node().unwrap(), "A");
+		let f_entry = tracker.entries.get(&"F2".to_string()).unwrap();
+		assert_eq!(f_entry.ancestor_node().unwrap(), "A".to_string());
 		assert_eq!(f_entry.cumulative_vote, 100);
 	}
 
 	#[test]
 	fn graph_fork_at_node() {
 		let mut chain = DummyChain::new();
-		let mut tracker1 = VoteGraph::new(GENESIS_HASH, 1, 0u32);
-		let mut tracker2 = VoteGraph::new(GENESIS_HASH, 1, 0u32);
+		let mut tracker1 = VoteGraph::new(GENESIS_HASH.into(), 1, 0u32);
+		let mut tracker2 = VoteGraph::new(GENESIS_HASH.into(), 1, 0u32);
 
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C"]);
-		chain.push_blocks("C", &["D1", "E1", "F1"]);
-		chain.push_blocks("C", &["D2", "E2", "F2"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string()]);
+		chain.push_blocks("C".into(), &["D1".to_string(), "E1".to_string(), "F1".to_string()]);
+		chain.push_blocks("C".into(), &["D2".to_string(), "E2".to_string(), "F2".to_string()]);
 
-		tracker1.insert("C", 4, 100, &chain).unwrap();
-		tracker1.insert("E1", 6, 100, &chain).unwrap();
-		tracker1.insert("F2", 7, 100, &chain).unwrap();
+		tracker1.insert("C".to_string(), 4, 100, &chain).unwrap();
+		tracker1.insert("E1".to_string(), 6, 100, &chain).unwrap();
+		tracker1.insert("F2".to_string(), 7, 100, &chain).unwrap();
 
-		tracker2.insert("E1", 6, 100, &chain).unwrap();
-		tracker2.insert("F2", 7, 100, &chain).unwrap();
-		tracker2.insert("C", 4, 100, &chain).unwrap();
+		tracker2.insert("E1".to_string(), 6, 100, &chain).unwrap();
+		tracker2.insert("F2".to_string(), 7, 100, &chain).unwrap();
+		tracker2.insert("C".to_string(), 4, 100, &chain).unwrap();
 
 		for tracker in &[&tracker1, &tracker2] {
-			assert!(tracker.heads.contains("E1"));
-			assert!(tracker.heads.contains("F2"));
-			assert!(!tracker.heads.contains("C"));
+			assert!(tracker.heads.contains(&"E1".to_string()));
+			assert!(tracker.heads.contains(&"F2".to_string()));
+			assert!(!tracker.heads.contains(&"C".to_string()));
 
-			let c_entry = tracker.entries.get("C").unwrap();
-			assert!(c_entry.descendents.contains(&"E1"));
-			assert!(c_entry.descendents.contains(&"F2"));
+			let c_entry = tracker.entries.get(&"C".to_string()).unwrap();
+			assert!(c_entry.descendents.contains(&"E1".to_string()));
+			assert!(c_entry.descendents.contains(&"F2".to_string()));
 			assert_eq!(c_entry.ancestor_node().unwrap(), GENESIS_HASH);
 			assert_eq!(c_entry.cumulative_vote, 300);
 
-			let e_entry = tracker.entries.get("E1").unwrap();
-			assert_eq!(e_entry.ancestor_node().unwrap(), "C");
+			let e_entry = tracker.entries.get(&"E1".to_string()).unwrap();
+			assert_eq!(e_entry.ancestor_node().unwrap(), "C".to_string());
 			assert_eq!(e_entry.cumulative_vote, 100);
 
-			let f_entry = tracker.entries.get("F2").unwrap();
-			assert_eq!(f_entry.ancestor_node().unwrap(), "C");
+			let f_entry = tracker.entries.get(&"F2".to_string()).unwrap();
+			assert_eq!(f_entry.ancestor_node().unwrap(), "C".to_string());
 			assert_eq!(f_entry.cumulative_vote, 100);
 		}
 	}
@@ -636,209 +636,209 @@ mod tests {
 	#[test]
 	fn ghost_merge_at_node() {
 		let mut chain = DummyChain::new();
-		let mut tracker = VoteGraph::new(GENESIS_HASH, 1, 0u32);
+		let mut tracker = VoteGraph::new(GENESIS_HASH.into(), 1, 0u32);
 
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C"]);
-		chain.push_blocks("C", &["D1", "E1", "F1"]);
-		chain.push_blocks("C", &["D2", "E2", "F2"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string()]);
+		chain.push_blocks("C".into(), &["D1".to_string(), "E1".to_string(), "F1".to_string()]);
+		chain.push_blocks("C".into(), &["D2".to_string(), "E2".to_string(), "F2".to_string()]);
 
-		tracker.insert("B", 3, 0, &chain).unwrap();
-		tracker.insert("C", 4, 100, &chain).unwrap();
-		tracker.insert("E1", 6, 100, &chain).unwrap();
-		tracker.insert("F2", 7, 100, &chain).unwrap();
+		tracker.insert("B".to_string(), 3, 0, &chain).unwrap();
+		tracker.insert("C".to_string(), 4, 100, &chain).unwrap();
+		tracker.insert("E1".to_string(), 6, 100, &chain).unwrap();
+		tracker.insert("F2".to_string(), 7, 100, &chain).unwrap();
 
-		assert_eq!(tracker.find_ghost(None, |&x| x >= 250), Some(("C", 4)));
-		assert_eq!(tracker.find_ghost(Some(("C", 4)), |&x| x >= 250), Some(("C", 4)));
-		assert_eq!(tracker.find_ghost(Some(("B", 3)), |&x| x >= 250), Some(("C", 4)));
+		assert_eq!(tracker.find_ghost(None, |&x| x >= 250), Some(("C".to_string(), 4)));
+		assert_eq!(tracker.find_ghost(Some(("C".to_string(), 4)), |&x| x >= 250), Some(("C".to_string(), 4)));
+		assert_eq!(tracker.find_ghost(Some(("B".to_string(), 3)), |&x| x >= 250), Some(("C".to_string(), 4)));
 	}
 
 	#[test]
 	fn ghost_merge_not_at_node_one_side_weighted() {
 		let mut chain = DummyChain::new();
-		let mut tracker = VoteGraph::new(GENESIS_HASH, 1, 0u32);
+		let mut tracker = VoteGraph::new(GENESIS_HASH.into(), 1, 0u32);
 
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C", "D", "E", "F"]);
-		chain.push_blocks("F", &["G1", "H1", "I1"]);
-		chain.push_blocks("F", &["G2", "H2", "I2"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string(), "D".to_string(), "E".to_string(), "F".to_string()]);
+		chain.push_blocks("F".to_string(), &["G1".to_string(), "H1".to_string(), "I1".to_string()]);
+		chain.push_blocks("F".to_string(), &["G2".to_string(), "H2".to_string(), "I2".to_string()]);
 
-		tracker.insert("B", 3, 0, &chain).unwrap();
-		tracker.insert("G1", 8, 100, &chain).unwrap();
-		tracker.insert("H2", 9, 150, &chain).unwrap();
+		tracker.insert("B".to_string(), 3, 0, &chain).unwrap();
+		tracker.insert("G1".to_string(), 8, 100, &chain).unwrap();
+		tracker.insert("H2".to_string(), 9, 150, &chain).unwrap();
 
-		assert_eq!(tracker.find_ghost(None, |&x| x >= 250), Some(("F", 7)));
-		assert_eq!(tracker.find_ghost(Some(("F", 7)), |&x| x >= 250), Some(("F", 7)));
-		assert_eq!(tracker.find_ghost(Some(("C", 4)), |&x| x >= 250), Some(("F", 7)));
-		assert_eq!(tracker.find_ghost(Some(("B", 3)), |&x| x >= 250), Some(("F", 7)));
+		assert_eq!(tracker.find_ghost(None, |&x| x >= 250), Some(("F".to_string(), 7)));
+		assert_eq!(tracker.find_ghost(Some(("F".to_string(), 7)), |&x| x >= 250), Some(("F".to_string(), 7)));
+		assert_eq!(tracker.find_ghost(Some(("C".to_string(), 4)), |&x| x >= 250), Some(("F".to_string(), 7)));
+		assert_eq!(tracker.find_ghost(Some(("B".to_string(), 3)), |&x| x >= 250), Some(("F".to_string(), 7)));
 	}
 
 	#[test]
 	fn ghost_introduce_branch() {
 		let mut chain = DummyChain::new();
-		let mut tracker = VoteGraph::new(GENESIS_HASH, 1, 0u32);
+		let mut tracker = VoteGraph::new(GENESIS_HASH.into(), 1, 0u32);
 
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C", "D", "E", "F"]);
-		chain.push_blocks("E", &["EA", "EB", "EC", "ED"]);
-		chain.push_blocks("F", &["FA", "FB", "FC"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string(), "D".to_string(), "E".to_string(), "F".to_string()]);
+		chain.push_blocks("E".to_string(), &["EA".to_string(), "EB".to_string(), "EC".to_string(), "ED".to_string()]);
+		chain.push_blocks("F".to_string(), &["FA".to_string(), "FB".to_string(), "FC".to_string()]);
 
-		tracker.insert("FC", 10, 5, &chain).unwrap();
-		tracker.insert("ED", 10, 7, &chain).unwrap();
+		tracker.insert("FC".to_string(), 10, 5, &chain).unwrap();
+		tracker.insert("ED".to_string(), 10, 7, &chain).unwrap();
 
-		assert_eq!(tracker.find_ghost(None, |&x| x >= 10), Some(("E", 6)));
+		assert_eq!(tracker.find_ghost(None, |&x| x >= 10), Some(("E".to_string(), 6)));
 
-		assert_eq!(tracker.entries.get(GENESIS_HASH).unwrap().descendents, vec!["FC", "ED"]);
+		assert_eq!(tracker.entries.get(GENESIS_HASH.into()).unwrap().descendents, vec!["FC".to_string(), "ED".to_string()]);
 
 		// introduce a branch in the middle.
-		tracker.insert("E", 6, 3, &chain).unwrap();
+		tracker.insert("E".to_string(), 6, 3, &chain).unwrap();
 
-		assert_eq!(tracker.entries.get(GENESIS_HASH).unwrap().descendents, vec!["E"]);
+		assert_eq!(tracker.entries.get(GENESIS_HASH.into()).unwrap().descendents, vec!["E"]);
 		let descendents = &tracker.entries.get("E").unwrap().descendents;
 		assert_eq!(descendents.len(), 2);
-		assert!(descendents.contains(&"ED"));
-		assert!(descendents.contains(&"FC"));
+		assert!(descendents.contains(&"ED".to_string()));
+		assert!(descendents.contains(&"FC".to_string()));
 
-		assert_eq!(tracker.find_ghost(None, |&x| x >= 10), Some(("E", 6)));
-		assert_eq!(tracker.find_ghost(Some(("C", 4)), |&x| x >= 10), Some(("E", 6)));
-		assert_eq!(tracker.find_ghost(Some(("E", 6)), |&x| x >= 10), Some(("E", 6)));
+		assert_eq!(tracker.find_ghost(None, |&x| x >= 10), Some(("E".to_string(), 6)));
+		assert_eq!(tracker.find_ghost(Some(("C".to_string(), 4)), |&x| x >= 10), Some(("E".to_string(), 6)));
+		assert_eq!(tracker.find_ghost(Some(("E".to_string(), 6)), |&x| x >= 10), Some(("E".to_string(), 6)));
 	}
 
 	#[test]
 	fn walk_back_from_block_in_edge_fork_below() {
 		let mut chain = DummyChain::new();
-		let mut tracker = VoteGraph::new(GENESIS_HASH, 1, 0u32);
+		let mut tracker = VoteGraph::new(GENESIS_HASH.into(), 1, 0u32);
 
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C"]);
-		chain.push_blocks("C", &["D1", "E1", "F1", "G1", "H1", "I1"]);
-		chain.push_blocks("C", &["D2", "E2", "F2", "G2", "H2", "I2"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string()]);
+		chain.push_blocks("C".to_string(), &["D1".to_string(), "E1".to_string(), "F1".to_string(), "G1".to_string(), "H1".to_string(), "I1".to_string()]);
+		chain.push_blocks("C".to_string(), &["D2".to_string(), "E2".to_string(), "F2".to_string(), "G2".to_string(), "H2".to_string(), "I2".to_string()]);
 
-		tracker.insert("B", 3, 10, &chain).unwrap();
-		tracker.insert("F1", 7, 5, &chain).unwrap();
-		tracker.insert("G2", 8, 5, &chain).unwrap();
+		tracker.insert("B".to_string(), 3, 10, &chain).unwrap();
+		tracker.insert("F1".to_string(), 7, 5, &chain).unwrap();
+		tracker.insert("G2".to_string(), 8, 5, &chain).unwrap();
 
-		let test_cases = &[
-			"D1",
-			"D2",
-			"E1",
-			"E2",
-			"F1",
-			"F2",
-			"G2",
+		let test_cases = [
+			"D1".to_string(),
+			"D2".to_string(),
+			"E1".to_string(),
+			"E2".to_string(),
+			"F1".to_string(),
+			"F2".to_string(),
+			"G2".to_string(),
 		];
 
-		for block in test_cases {
-			let number = chain.number(block);
-			assert_eq!(tracker.find_ancestor(block, number, |&x| x > 5).unwrap(), ("C", 4));
+		for block in test_cases.iter() {
+			let number = chain.number(block.clone());
+			assert_eq!(tracker.find_ancestor(block.clone(), number, |&x| x > 5).unwrap(), ("C".to_string(), 4));
 		}
 	}
 
 	#[test]
 	fn walk_back_from_fork_block_node_below() {
 		let mut chain = DummyChain::new();
-		let mut tracker = VoteGraph::new(GENESIS_HASH, 1, 0u32);
+		let mut tracker = VoteGraph::new(GENESIS_HASH.into(), 1, 0u32);
 
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C", "D"]);
-		chain.push_blocks("D", &["E1", "F1", "G1", "H1", "I1"]);
-		chain.push_blocks("D", &["E2", "F2", "G2", "H2", "I2"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string(), "D".to_string()]);
+		chain.push_blocks("D".to_string(), &["E1".to_string(), "F1".to_string(), "G1".to_string(), "H1".to_string(), "I1".to_string()]);
+		chain.push_blocks("D".to_string(), &["E2".to_string(), "F2".to_string(), "G2".to_string(), "H2".to_string(), "I2".to_string()]);
 
-		tracker.insert("B", 3, 10, &chain).unwrap();
-		tracker.insert("F1", 7, 5, &chain).unwrap();
-		tracker.insert("G2", 8, 5, &chain).unwrap();
+		tracker.insert("B".to_string(), 3, 10, &chain).unwrap();
+		tracker.insert("F1".to_string(), 7, 5, &chain).unwrap();
+		tracker.insert("G2".to_string(), 8, 5, &chain).unwrap();
 
-		assert_eq!(tracker.find_ancestor("G2", 8, |&x| x > 5).unwrap(), ("D", 5));
+		assert_eq!(tracker.find_ancestor("G2".to_string(), 8, |&x| x > 5).unwrap(), ("D".to_string(), 5));
 		let test_cases = &[
-			"E1",
-			"E2",
-			"F1",
-			"F2",
-			"G2",
+			"E1".to_string(),
+			"E2".to_string(),
+			"F1".to_string(),
+			"F2".to_string(),
+			"G2".to_string(),
 		];
 
 		for block in test_cases {
-			let number = chain.number(block);
-			assert_eq!(tracker.find_ancestor(block, number, |&x| x > 5).unwrap(), ("D", 5));
+			let number = chain.number(block.clone());
+			assert_eq!(tracker.find_ancestor(block.clone(), number, |&x| x > 5).unwrap(), ("D".to_string(), 5));
 		}
 	}
 
 	#[test]
 	fn walk_back_at_node() {
 		let mut chain = DummyChain::new();
-		let mut tracker = VoteGraph::new(GENESIS_HASH, 1, 0u32);
+		let mut tracker = VoteGraph::new(GENESIS_HASH.into(), 1, 0u32);
 
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C"]);
-		chain.push_blocks("C", &["D1", "E1", "F1", "G1", "H1", "I1"]);
-		chain.push_blocks("C", &["D2", "E2", "F2"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string()]);
+		chain.push_blocks("C".to_string(), &["D1".to_string(), "E1".to_string(), "F1".to_string(), "G1".to_string(), "H1".to_string(), "I1".to_string()]);
+		chain.push_blocks("C".to_string(), &["D2".to_string(), "E2".to_string(), "F2".to_string()]);
 
-		tracker.insert("C", 4, 10, &chain).unwrap();
-		tracker.insert("F1", 7, 5, &chain).unwrap();
-		tracker.insert("F2", 7, 5, &chain).unwrap();
-		tracker.insert("I1", 10, 1, &chain).unwrap();
+		tracker.insert("C".to_string(), 4, 10, &chain).unwrap();
+		tracker.insert("F1".to_string(), 7, 5, &chain).unwrap();
+		tracker.insert("F2".to_string(), 7, 5, &chain).unwrap();
+		tracker.insert("I1".to_string(), 10, 1, &chain).unwrap();
 
 		let test_cases = &[
-			"C",
-			"D1",
-			"D2",
-			"E1",
-			"E2",
-			"F1",
-			"F2",
-			"I1",
+			"C".to_string(),
+			"D1".to_string(),
+			"D2".to_string(),
+			"E1".to_string(),
+			"E2".to_string(),
+			"F1".to_string(),
+			"F2".to_string(),
+			"I1".to_string(),
 		];
 
 		for block in test_cases {
-			let number = chain.number(block);
-			assert_eq!(tracker.find_ancestor(block, number, |&x| x >= 20).unwrap(), ("C", 4));
+			let number = chain.number(block.clone());
+			assert_eq!(tracker.find_ancestor(block.clone(), number, |&x| x >= 20).unwrap(), ("C".to_string(), 4));
 		}
 	}
 
 	#[test]
 	fn adjust_base() {
 		let mut chain = DummyChain::new();
-		let mut tracker = VoteGraph::new("E", 6, 0u32);
+		let mut tracker = VoteGraph::new("E".to_string(), 6, 0u32);
 
-		chain.push_blocks(GENESIS_HASH, &["A", "B", "C", "D", "E", "F"]);
-		chain.push_blocks("E", &["EA", "EB", "EC", "ED"]);
-		chain.push_blocks("F", &["FA", "FB", "FC"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string(), "B".to_string(), "C".to_string(), "D".to_string(), "E".to_string(), "F".to_string()]);
+		chain.push_blocks("E".to_string(), &["EA".to_string(), "EB".to_string(), "EC".to_string(), "ED".to_string()]);
+		chain.push_blocks("F".to_string(), &["FA".to_string(), "FB".to_string(), "FC".to_string()]);
 
-		tracker.insert("FC", 10, 5, &chain).unwrap();
-		tracker.insert("ED", 10, 7, &chain).unwrap();
+		tracker.insert("FC".to_string(), 10, 5, &chain).unwrap();
+		tracker.insert("ED".to_string(), 10, 7, &chain).unwrap();
 
-		assert_eq!(tracker.base(), ("E", 6));
+		assert_eq!(tracker.base(), ("E".to_string(), 6));
 
-		tracker.adjust_base(&["D", "C", "B", "A"]);
+		tracker.adjust_base(&["D".to_string(), "C".to_string(), "B".to_string(), "A".to_string()]);
 
-		assert_eq!(tracker.base(), ("A", 2));
+		assert_eq!(tracker.base(), ("A".to_string(), 2));
 
-		chain.push_blocks("A", &["3", "4", "5"]);
+		chain.push_blocks("A".to_string(), &["3".to_string(), "4".to_string(), "5".to_string()]);
 
-		tracker.adjust_base(&[GENESIS_HASH]);
-		assert_eq!(tracker.base(), (GENESIS_HASH, 1));
+		tracker.adjust_base(&[GENESIS_HASH.into()]);
+		assert_eq!(tracker.base(), (GENESIS_HASH.into(), 1));
 
-		assert_eq!(tracker.entries.get(GENESIS_HASH).unwrap().cumulative_vote, 12);
+		assert_eq!(tracker.entries.get(GENESIS_HASH.into()).unwrap().cumulative_vote, 12);
 
-		tracker.insert("5", 5, 3, &chain).unwrap();
+		tracker.insert("5".to_string(), 5, 3, &chain).unwrap();
 
-		assert_eq!(tracker.entries.get(GENESIS_HASH).unwrap().cumulative_vote, 15);
+		assert_eq!(tracker.entries.get(GENESIS_HASH.into()).unwrap().cumulative_vote, 15);
 	}
 
 	#[test]
 	fn find_ancestor_is_largest() {
 		let mut chain = DummyChain::new();
-		let mut tracker = VoteGraph::new(GENESIS_HASH, 0, 0);
+		let mut tracker = VoteGraph::new(GENESIS_HASH.into(), 0, 0);
 
-		chain.push_blocks(GENESIS_HASH, &["A"]);
-		chain.push_blocks(GENESIS_HASH, &["B"]);
-		chain.push_blocks("A", &["A1"]);
-		chain.push_blocks("A", &["A2"]);
-		chain.push_blocks("B", &["B1"]);
-		chain.push_blocks("B", &["B2"]);
+		chain.push_blocks(GENESIS_HASH.into(), &["A".to_string()]);
+		chain.push_blocks(GENESIS_HASH.into(), &["B".to_string()]);
+		chain.push_blocks("A".to_string(), &["A1".to_string()]);
+		chain.push_blocks("A".to_string(), &["A2".to_string()]);
+		chain.push_blocks("B".to_string(), &["B1".to_string()]);
+		chain.push_blocks("B".to_string(), &["B2".to_string()]);
 
 		// Inserting the Bs first used to exhibit incorrect behaviour.
-		tracker.insert("B1", 2, 1, &chain).unwrap();
-		tracker.insert("B2", 2, 1, &chain).unwrap();
-		tracker.insert("A1", 2, 1, &chain).unwrap();
-		tracker.insert("A2", 2, 1, &chain).unwrap();
+		tracker.insert("B1".to_string(), 2, 1, &chain).unwrap();
+		tracker.insert("B2".to_string(), 2, 1, &chain).unwrap();
+		tracker.insert("A1".to_string(), 2, 1, &chain).unwrap();
+		tracker.insert("A2".to_string(), 2, 1, &chain).unwrap();
 
-		let actual = tracker.find_ancestor("A", 1, |x| x >= &2).unwrap();
+		let actual = tracker.find_ancestor("A".to_string(), 1, |x| x >= &2).unwrap();
 		// `actual` used to (incorrectly) be (genesis, 0)
-		assert_eq!(actual, ("A", 1));
+		assert_eq!(actual, ("A".to_string(), 1));
 	}
 }

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -1236,6 +1236,8 @@ mod tests {
 
 	#[test]
 	fn broadcast_commit() {
+		env_logger::init();
+
 		let local_id = Id(5);
 		let voters = VoterSet::new([(local_id, 100)].iter().cloned()).expect("nonempty");
 

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -740,14 +740,14 @@ impl<H, N, E: Environment<H, N> + Send + Sync, GlobalIn, GlobalOut> Voter<H, N, 
 			let mut inner = self.inner.write().await;
 
 			let should_start_next = {
-				inner.best_round.poll().await?;
+				let completable = inner.best_round.poll().await?;
 
 				let precommitted = match inner.best_round.state() {
 					Some(&VotingRoundState::Precommitted) => true, // start when we've cast all votes.
 					_ => false,
 				};
 
-				precommitted
+				completable && precommitted
 			};
 
 			if !should_start_next { return Ok(()) }

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -200,7 +200,7 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 
 		// broadcast finality notifications after attempting to cast votes
 		let post_state = self.votes.state();
-		self.notify(pre_state, post_state);
+		self.notify(pre_state, post_state).await;
 
 		// make sure that the previous round estimate has been finalized
 		let last_round_estimate_finalized = match last_round_state {
@@ -639,10 +639,10 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 	}
 
 	// notify when new blocks are finalized or when the round-estimate is updated
-	fn notify(&mut self, last_state: RoundState<H, N>, new_state: RoundState<H, N>) {
+	async fn notify(&mut self, last_state: RoundState<H, N>, new_state: RoundState<H, N>) {
 		if last_state != new_state {
 			if let Some(ref b) = self.bridged_round_state {
-				b.update(new_state.clone());
+				b.update(new_state.clone()).await;
 			}
 		}
 

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -184,7 +184,11 @@ impl<H, N, E: Environment<H, N>> VotingRound<H, N, E> where
 		// we only cast votes when we have access to the previous round state.
 		// we might have started this round as a prospect "future" round to
 		// check whether the voter is lagging behind the current round.
-		let last_round_state = self.last_round_state.as_ref().map(|s| s.get().clone());
+		let last_round_state = match self.last_round_state.as_ref() {
+			Some(s) => Some(s.get().await.clone()),
+			None => None,
+		};
+
 		if let Some(ref last_round_state) = last_round_state {
 			self.primary_propose(last_round_state)?;
 			self.prevote(last_round_state).await?;


### PR DESCRIPTION
This is my attempt at trying to upgrade this crate from using futures into async-await. The reason behind this change is to be able to convert substrate's consensus including finality-grandpa's `Environment` methods to async ones where `await` can be used on calls to the keystore.

The status of this PR is WIP. The following tests need to be fixed before this branch can be merged:
```
test voter::tests::broadcast_commit ... FAILED
test voter::tests::exposing_voter_state ... FAILED
```
and
```
test voter::tests::broadcast_commit_only_if_newer ... test voter::tests::broadcast_commit_only_if_newer has been running for over 60 seconds
test voter::tests::finalizing_at_fault_threshold ... test voter::tests::finalizing_at_fault_threshold has been running for over 60 seconds
test voter::tests::import_commit_for_any_round ... test voter::tests::import_commit_for_any_round has been running for over 60 seconds
test voter::tests::pick_up_from_prior_with_grandparent_state ... test voter::tests::pick_up_from_prior_with_grandparent_state has been running for over 60 seconds
test voter::tests::pick_up_from_prior_without_grandparent_state ... test voter::tests::pick_up_from_prior_without_grandparent_state has been running for over 60 seconds
test voter::tests::skips_to_latest_round_after_catch_up ... test voter::tests::skips_to_latest_round_after_catch_up has been running for over 60 seconds
test voter::tests::talking_to_myself ... test voter::tests::talking_to_myself has been running for over 60 seconds
```

I am going to keep this draft PR around to be picked up later by someone knowledgable in finality-grandpa's logic to make the needed fixes and maybe get this PR to a mergable state.

Resolves #124 