### PR TITLE
Add `scale_info::TypeInfo` derives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand = "0.8"
 
 [features]
 default = ["std"]
-std = ["parity-scale-codec/std", "num/std", "parking_lot", "log", "futures-timer", "futures/executor"]
+std = ["parity-scale-codec/std", "num/std", "parking_lot", "log", "futures-timer", "futures/executor", "scale-info/std"]
 derive-codec = ["parity-scale-codec", "scale-info"]
 test-helpers = ["fuzz-helpers", "rand", "std"]
 fuzz-helpers = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures-timer = { version = "3.0", optional = true }
 log = { version = "0.4", optional = true }
 num = { package = "num-traits", version = "0.2", default-features = false }
 parity-scale-codec = { version = "2.0", default-features = false, features = ["derive"], optional = true }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-substrate", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.7.0", default-features = false, features = ["derive"], optional = true }
 parking_lot = { version = "0.11", optional = true }
 rand = { version = "0.8", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finality-grandpa"
-version = "0.14.2"
+version = "0.15.0"
 description = "PBFT-based finality gadget for blockchains"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ num = { package = "num-traits", version = "0.2", default-features = false }
 parity-scale-codec = { version = "2.0", default-features = false, features = ["derive"], optional = true }
 parking_lot = { version = "0.11", optional = true }
 rand = { version = "0.8", optional = true }
-scale-info = { version = "0.9.0", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.10.0", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 quickcheck = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures-timer = { version = "3.0", optional = true }
 log = { version = "0.4", optional = true }
 num = { package = "num-traits", version = "0.2", default-features = false }
 parity-scale-codec = { version = "2.0", default-features = false, features = ["derive"], optional = true }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "master", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-remove-compact-type-bounds", default-features = false, features = ["derive"], optional = true }
 parking_lot = { version = "0.11", optional = true }
 rand = { version = "0.8", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures-timer = { version = "3.0", optional = true }
 log = { version = "0.4", optional = true }
 num = { package = "num-traits", version = "0.2", default-features = false }
 parity-scale-codec = { version = "2.0", default-features = false, features = ["derive"], optional = true }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-remove-compact-type-bounds", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-substrate", default-features = false, features = ["derive"], optional = true }
 parking_lot = { version = "0.11", optional = true }
 rand = { version = "0.8", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ futures-timer = { version = "3.0", optional = true }
 log = { version = "0.4", optional = true }
 num = { package = "num-traits", version = "0.2", default-features = false }
 parity-scale-codec = { version = "2.0", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "master", default-features = false, features = ["derive"], optional = true }
 parking_lot = { version = "0.11", optional = true }
 rand = { version = "0.8", optional = true }
 
@@ -24,6 +25,6 @@ rand = "0.8"
 [features]
 default = ["std"]
 std = ["parity-scale-codec/std", "num/std", "parking_lot", "log", "futures-timer", "futures/executor"]
-derive-codec = ["parity-scale-codec"]
+derive-codec = ["parity-scale-codec", "scale-info"]
 test-helpers = ["fuzz-helpers", "rand", "std"]
 fuzz-helpers = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finality-grandpa"
-version = "0.15.0"
+version = "0.14.3"
 description = "PBFT-based finality gadget for blockchains"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures-timer = { version = "3.0", optional = true }
 log = { version = "0.4", optional = true }
 num = { package = "num-traits", version = "0.2", default-features = false }
 parity-scale-codec = { version = "2.0", default-features = false, features = ["derive"], optional = true }
-scale-info = { version = "0.7.0", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9.0", default-features = false, features = ["derive"], optional = true }
 parking_lot = { version = "0.11", optional = true }
 rand = { version = "0.8", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,11 +78,13 @@ use crate::std::vec::Vec;
 use crate::voter_set::VoterSet;
 #[cfg(feature = "derive-codec")]
 use parity_scale_codec::{Encode, Decode};
+#[cfg(feature = "derive-codec")]
+use scale_info::TypeInfo;
 use round::ImportResult;
 
 /// A prevote for a block and its ancestors.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub struct Prevote<H, N> {
 	/// The target block's hash.
 	pub target_hash: H,
@@ -99,7 +101,7 @@ impl<H, N> Prevote<H, N> {
 
 /// A precommit for a block and its ancestors.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub struct Precommit<H, N> {
 	/// The target block's hash.
 	pub target_hash: H,
@@ -117,7 +119,7 @@ impl<H, N> Precommit<H, N> {
 /// A primary proposed block, this is a broadcast of the last round's estimate.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub struct PrimaryPropose<H, N> {
 	/// The target block's hash.
 	pub target_hash: H,
@@ -205,7 +207,7 @@ pub trait Chain<H: Eq, N: Copy + BlockNumberOps> {
 
 /// An equivocation (double-vote) in a given round.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub struct Equivocation<Id, V, S> {
 	/// The round number equivocated in.
 	pub round_number: u64,
@@ -220,7 +222,7 @@ pub struct Equivocation<Id, V, S> {
 /// A protocol message or vote.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub enum Message<H, N> {
 	/// A prevote message.
 	#[cfg_attr(feature = "derive-codec", codec(index = 0))]
@@ -247,7 +249,7 @@ impl<H, N: Copy> Message<H, N> {
 /// A signed message.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub struct SignedMessage<H, N, S, Id> {
 	/// The internal message which has been signed.
 	pub message: Message<H, N>,
@@ -269,7 +271,7 @@ impl<H, N: Copy, S, Id> SignedMessage<H, N, S, Id> {
 /// A commit message which is an aggregate of precommits.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub struct Commit<H, N, S, Id> {
 	/// The target block's hash.
 	pub target_hash: H,
@@ -282,7 +284,7 @@ pub struct Commit<H, N, S, Id> {
 /// A signed prevote message.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub struct SignedPrevote<H, N, S, Id> {
 	/// The prevote message which has been signed.
 	pub prevote: Prevote<H, N>,
@@ -295,7 +297,7 @@ pub struct SignedPrevote<H, N, S, Id> {
 /// A signed precommit message.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub struct SignedPrecommit<H, N, S, Id> {
 	/// The precommit message which has been signed.
 	pub precommit: Precommit<H, N>,
@@ -308,7 +310,7 @@ pub struct SignedPrecommit<H, N, S, Id> {
 /// A commit message with compact representation of authentication data.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub struct CompactCommit<H, N, S, Id> {
 	/// The target block's hash.
 	pub target_hash: H,
@@ -327,7 +329,7 @@ pub struct CompactCommit<H, N, S, Id> {
 /// a descendent of.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub struct CatchUp<H, N, S, Id> {
 	/// Round number.
 	pub round_number: u64,
@@ -514,7 +516,7 @@ pub fn process_commit_validation_result<H, N>(
 /// Historical votes seen in a round.
 #[derive(Default, Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, TypeInfo))]
 pub struct HistoricalVotes<H, N, S, Id> {
 	seen: Vec<SignedMessage<H, N, S, Id>>,
 	prevote_idx: Option<u64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ use round::ImportResult;
 
 /// A prevote for a block and its ancestors.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct Prevote<H, N> {
 	/// The target block's hash.
 	pub target_hash: H,
@@ -99,7 +99,7 @@ impl<H, N> Prevote<H, N> {
 
 /// A precommit for a block and its ancestors.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct Precommit<H, N> {
 	/// The target block's hash.
 	pub target_hash: H,
@@ -117,7 +117,7 @@ impl<H, N> Precommit<H, N> {
 /// A primary proposed block, this is a broadcast of the last round's estimate.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct PrimaryPropose<H, N> {
 	/// The target block's hash.
 	pub target_hash: H,
@@ -205,7 +205,7 @@ pub trait Chain<H: Eq, N: Copy + BlockNumberOps> {
 
 /// An equivocation (double-vote) in a given round.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct Equivocation<Id, V, S> {
 	/// The round number equivocated in.
 	pub round_number: u64,
@@ -220,7 +220,7 @@ pub struct Equivocation<Id, V, S> {
 /// A protocol message or vote.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub enum Message<H, N> {
 	/// A prevote message.
 	#[cfg_attr(feature = "derive-codec", codec(index = 0))]
@@ -247,7 +247,7 @@ impl<H, N: Copy> Message<H, N> {
 /// A signed message.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct SignedMessage<H, N, S, Id> {
 	/// The internal message which has been signed.
 	pub message: Message<H, N>,
@@ -269,7 +269,7 @@ impl<H, N: Copy, S, Id> SignedMessage<H, N, S, Id> {
 /// A commit message which is an aggregate of precommits.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct Commit<H, N, S, Id> {
 	/// The target block's hash.
 	pub target_hash: H,
@@ -282,7 +282,7 @@ pub struct Commit<H, N, S, Id> {
 /// A signed prevote message.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct SignedPrevote<H, N, S, Id> {
 	/// The prevote message which has been signed.
 	pub prevote: Prevote<H, N>,
@@ -295,7 +295,7 @@ pub struct SignedPrevote<H, N, S, Id> {
 /// A signed precommit message.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct SignedPrecommit<H, N, S, Id> {
 	/// The precommit message which has been signed.
 	pub precommit: Precommit<H, N>,
@@ -308,7 +308,7 @@ pub struct SignedPrecommit<H, N, S, Id> {
 /// A commit message with compact representation of authentication data.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct CompactCommit<H, N, S, Id> {
 	/// The target block's hash.
 	pub target_hash: H,
@@ -327,7 +327,7 @@ pub struct CompactCommit<H, N, S, Id> {
 /// a descendent of.
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct CatchUp<H, N, S, Id> {
 	/// Round number.
 	pub round_number: u64,
@@ -514,7 +514,7 @@ pub fn process_commit_validation_result<H, N>(
 /// Historical votes seen in a round.
 #[derive(Default, Clone, PartialEq, Eq)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct HistoricalVotes<H, N, S, Id> {
 	seen: Vec<SignedMessage<H, N, S, Id>>,
 	prevote_idx: Option<u64>,

--- a/src/round.rs
+++ b/src/round.rs
@@ -159,7 +159,7 @@ impl<Id: Ord + Eq + Clone, Vote: Clone + Eq, Signature: Clone + Eq> VoteTracker<
 /// State of the round.
 #[derive(PartialEq, Clone)]
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
-#[cfg_attr(feature = "derive-codec", derive(Encode, Decode))]
+#[cfg_attr(feature = "derive-codec", derive(Encode, Decode, scale_info::TypeInfo))]
 pub struct State<H, N> {
 	/// The prevote-GHOST block.
 	pub prevote_ghost: Option<(H, N)>,


### PR DESCRIPTION
Required for work on https://github.com/paritytech/substrate/discussions/8370, used in branch https://github.com/paritytech/substrate/compare/aj-metadata-vnext.