### PR TITLE
remove RwLock to drop Sync bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finality-grandpa"
-version = "0.14.0"
+version = "0.14.1"
 description = "PBFT-based finality gadget for blockchains"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -205,20 +205,17 @@ pub mod environment {
 	}
 
 	impl crate::voter::Environment<&'static str, u32> for Environment {
-		type Timer = Box<dyn Future<Output = Result<(), Error>> + Unpin + Send + Sync>;
-		type BestChain = Box<
-			dyn Future<Output = Result<Option<(&'static str, u32)>, Error>> + Unpin + Send + Sync,
-		>;
+		type Timer = Box<dyn Future<Output = Result<(), Error>> + Unpin + Send>;
+		type BestChain =
+			Box<dyn Future<Output = Result<Option<(&'static str, u32)>, Error>> + Unpin + Send>;
 		type Id = Id;
 		type Signature = Signature;
 		type In = Box<
 			dyn Stream<Item = Result<SignedMessage<&'static str, u32, Signature, Id>, Error>>
 				+ Unpin
-				+ Send
-				+ Sync,
+				+ Send,
 		>;
-		type Out =
-			Pin<Box<dyn Sink<Message<&'static str, u32>, Error = Error> + Send + Sync + 'static>>;
+		type Out = Pin<Box<dyn Sink<Message<&'static str, u32>, Error = Error> + Send>>;
 		type Error = Error;
 
 		fn best_chain_containing(&self, base: &'static str) -> Self::BestChain {

--- a/src/vote_graph.rs
+++ b/src/vote_graph.rs
@@ -17,10 +17,13 @@
 //! See docs on `VoteGraph` for more information.
 
 use crate::std::{
-	self, collections::{BTreeMap, BTreeSet}, fmt::Debug, ops::AddAssign, vec::Vec,
+	collections::{BTreeMap, BTreeSet},
+	fmt::Debug,
+	ops::AddAssign,
+	vec::Vec,
 };
 
-use super::{Chain, Error, BlockNumberOps};
+use super::{BlockNumberOps, Chain, Error};
 
 #[cfg_attr(any(feature = "std", test), derive(Debug))]
 struct Entry<H, N, V> {

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -63,7 +63,7 @@ pub trait Environment<H: Eq, N: BlockNumberOps>: Chain<H, N> {
 	/// best chain to vote on. See also [`Self::best_chain_containing`].
 	type BestChain: Future<Output = Result<Option<(H, N)>, Self::Error>> + Send + Unpin;
 	/// The associated Id for the Environment.
-	type Id: Clone + Eq + Ord + Hash + std::fmt::Debug;
+	type Id: Clone + Eq + Ord + std::fmt::Debug;
 	/// The associated Signature type for the Environment.
 	type Signature: Eq + Clone;
 	/// The input stream used to communicate with the outside world.
@@ -500,7 +500,7 @@ impl<'a, H: 'a, N, E: 'a, GlobalIn, GlobalOut> Voter<H, N, E, GlobalIn, GlobalOu
 	pub fn voter_state(&self) -> Box<dyn VoterState<E::Id> + 'a + Send + Sync>
 	where
 		<E as Environment<H, N>>::Signature: Send,
-		<E as Environment<H, N>>::Id: Send,
+		<E as Environment<H, N>>::Id: Hash + Send,
 		<E as Environment<H, N>>::Timer: Send,
 		<E as Environment<H, N>>::Out: Send,
 		<E as Environment<H, N>>::In: Send,


### PR DESCRIPTION
This PR replaces a `RwLock` with a `Mutex` in order to remove all the existing `Sync` bounds. This should ease integration with the rest of the async/await ecosystem (e.g. async_trait). The `RwLock` is not exposed is almost never contended so in practice this shouldn't make any difference.