### PR TITLE
Bump parity-scale-codec to 2.2.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ futures = { version = "0.3", default-features = false }
 futures-timer = { version = "3.0", optional = true }
 log = { version = "0.4", optional = true }
 num = { package = "num-traits", version = "0.2", default-features = false }
-parity-scale-codec = { version = "2.2.0-rc.1", default-features = false, features = ["derive"], optional = true }
+parity-scale-codec = { version = "2.2.0-rc.2", default-features = false, features = ["derive"], optional = true }
 parking_lot = { version = "0.11", optional = true }
 rand = { version = "0.8", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finality-grandpa"
-version = "0.14.1"
+version = "0.14.2"
 description = "PBFT-based finality gadget for blockchains"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ futures = { version = "0.3", default-features = false }
 futures-timer = { version = "3.0", optional = true }
 log = { version = "0.4", optional = true }
 num = { package = "num-traits", version = "0.2", default-features = false }
-parity-scale-codec = { version = "2.0", default-features = false, features = ["derive"], optional = true }
+parity-scale-codec = { version = "2.2.0-rc.1", default-features = false, features = ["derive"], optional = true }
 parking_lot = { version = "0.11", optional = true }
 rand = { version = "0.8", optional = true }
 


### PR DESCRIPTION
Part of https://github.com/paritytech/substrate/pull/9163.

This is a pre-release so that we can experiment a bit more with the `MaxEncodedLen` trait if needed, but since Cargo wants pre-releases to be explicitly specified (and are not considered automatically SemVer-compatible), this does exactly that. That's also needed so that we can select a single `parity-scale-codec` version in the Substrate crate graph.