### PR TITLE
Revert depending on a pre-release of parity-scale-codec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ futures = { version = "0.3", default-features = false }
 futures-timer = { version = "3.0", optional = true }
 log = { version = "0.4", optional = true }
 num = { package = "num-traits", version = "0.2", default-features = false }
-parity-scale-codec = { version = "2.2.0-rc.2", default-features = false, features = ["derive"], optional = true }
+parity-scale-codec = { version = "2.0", default-features = false, features = ["derive"], optional = true }
 parking_lot = { version = "0.11", optional = true }
 rand = { version = "0.8", optional = true }
 


### PR DESCRIPTION
Undoes #137.

Sorry for the churn, we'll go with the approach outlined in https://github.com/paritytech/parity-common/pull/552#issuecomment-872252537 instead.

I'll yank `0.14.2` once this gets merged.