### PR TITLE
Links were pointing to outdated version

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ Usage is provided under the Apache License (Version 2.0). See [LICENSE](LICENSE)
 details.
 
 [blogpost]: https://medium.com/polkadot-network/grandpa-block-finality-in-polkadot-an-introduction-part-1-d08a24a021b5
-[chain-docs]: https://docs.rs/finality-grandpa/0.10.2/finality_grandpa/trait.Chain.html
+[chain-docs]: https://docs.rs/finality-grandpa/latest/finality_grandpa/trait.Chain.html
 [codecov-badge]: https://codecov.io/gh/paritytech/finality-grandpa/branch/master/graph/badge.svg
 [codecov]: https://codecov.io/gh/paritytech/finality-grandpa
 [crates-badge]: https://img.shields.io/crates/v/finality-grandpa.svg
 [crates]: https://crates.io/crates/finality-grandpa
-[environment-docs]: https://docs.rs/finality-grandpa/0.10.2/finality_grandpa/voter/trait.Environment.html
+[environment-docs]: https://docs.rs/finality-grandpa/latest/finality_grandpa/voter/trait.Environment.html
 [paper]: https://github.com/w3f/consensus/blob/master/pdf/grandpa.pdf
 [parity-scale-codec]: https://github.com/paritytech/parity-scale-codec
 [polkadot-wiki]: https://wiki.polkadot.network/en/latest/polkadot/learn/consensus/


### PR DESCRIPTION
I don't see any reason why we don't just point to 'latest' version for these traits.