### PR TITLE
nth() now O(1), get still O(log(n))

### DIFF
--- a/src/voter_set.rs
+++ b/src/voter_set.rs
@@ -55,9 +55,8 @@ impl<Id: Eq + Ord> VoterSet<Id> {
 		Id: Ord + Clone,
 		I: IntoIterator<Item = (Id, u64)>,
 	{
-		let mut voters = BTreeMap::new();
-
 		// Populate the voter set, thereby calculating the total weight.
+		let mut voters = BTreeMap::new();
 		let mut total_weight = 0u64;
 		for (id, weight) in weights {
 			if let Some(w) = NonZeroU64::new(weight) {
@@ -95,6 +94,7 @@ impl<Id: Eq + Ord> VoterSet<Id> {
 				(id, info)
 			})
 			.collect();
+
 		let total_weight = VoterWeight::new(total_weight).expect("voters nonempty; qed");
 
 		Some(VoterSet { voters, total_weight, threshold: threshold(total_weight) })

--- a/src/voter_set.rs
+++ b/src/voter_set.rs
@@ -32,7 +32,7 @@ use crate::{
 /// equipped with a total order, given by the ordering of the voter's IDs.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct VoterSet<Id: Eq + Ord> {
-	/// The total ordered voters set
+	/// The voters in the voter set, this vec is always sorted by the voter ID.
 	voters: Vec<(Id, VoterInfo)>,
 	/// The required weight threshold for supermajority w.r.t. this set.
 	threshold: VoterWeight,


### PR DESCRIPTION
I saw that we could still get down to one data structure and improve the nth() complexity to O(1) by using binary search on a vec sorted by Ids. We don't really need a BTreeMap as the structure is immutable - ordered inserts aren't needed once constructed.

The sort is like tim-sort i.e. very efficient if inputs happen to be already sorted by Id. Hopefully this is strictly better than what we had before in all dimensions.