### PR TITLE
Fix commit validation to allow precommits lower than commit target

### DIFF
--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -300,8 +300,7 @@ where
 		&mut self,
 		commit: &Commit<H, N, E::Signature, E::Id>,
 	) -> Result<Option<(H, N)>, E::Error> {
-		let base = validate_commit(commit, self.voters(), &*self.env)?.ghost;
-		if base.is_none() {
+		if !validate_commit(commit, self.voters(), &*self.env)?.is_valid() {
 			return Ok(None)
 		}
 
@@ -313,7 +312,7 @@ where
 			}
 		}
 
-		Ok(base)
+		Ok(Some((commit.target_hash.clone(), commit.target_number)))
 	}
 
 	/// Get a clone of the finalized sender.


### PR DESCRIPTION
This might be needed in a situation where there is an equivocation as part of the commit, which is treated as "voting for all blocks", and can therefore allow for finalizing a block higher than those precommits target. I added tests to cover these scenarios.