### PR TITLE
Fix typo in panic message

### DIFF
--- a/src/vote_graph.rs
+++ b/src/vote_graph.rs
@@ -546,7 +546,7 @@ where
 
 			assert!(
 				self.entries.insert(ancestor_hash, new_entry).is_none(),
-				"thus function is only invoked when there is no entry for the ancestor already; qed",
+				"this function is only invoked when there is no entry for the ancestor already; qed",
 			)
 		}
 	}


### PR DESCRIPTION
Was looking at the `VoteGraph` code and noticed a typo in the `introduce_branch` function.  