### PR TITLE
voter: Stop the voter logic on terminated global input stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 either = { version = "1.6", default-features = false }
 futures = { version = "0.3", default-features = false }
 futures-timer = { version = "3.0", optional = true }
-log = { version = "0.4", optional = true }
+tracing = { version = "0.1.41", default-features = false,  optional = true }
 num = { package = "num-traits", version = "0.2", default-features = false }
 parity-scale-codec = { version = "3", default-features = false, optional = true, features = [
     "derive",
@@ -32,7 +32,7 @@ std = [
     "parity-scale-codec/std",
     "num/std",
     "parking_lot",
-    "log",
+    "tracing",
     "futures-timer",
     "futures/executor",
     "scale-info/std",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,8 @@ impl<H, N> PrimaryPropose<H, N> {
 pub enum Error {
 	/// The block is not a descendent of the given base block.
 	NotDescendent,
+	/// The global stream was closed unexpectedly.
+	StreamClosed,
 }
 
 #[cfg(feature = "std")]
@@ -146,6 +148,7 @@ impl std::fmt::Display for Error {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		match *self {
 			Error::NotDescendent => write!(f, "Block not descendent of base"),
+			Error::StreamClosed => write!(f, "Stream closed unexpectedly"),
 		}
 	}
 }
@@ -155,6 +158,7 @@ impl std::error::Error for Error {
 	fn description(&self) -> &str {
 		match *self {
 			Error::NotDescendent => "Block not descendent of base",
+			Error::StreamClosed => "Stream closed unexpectedly",
 		}
 	}
 }
@@ -203,6 +207,7 @@ pub trait Chain<H: Eq, N: Copy + BlockNumberOps> {
 		match self.ancestry(base, block) {
 			Ok(_) => true,
 			Err(Error::NotDescendent) => false,
+			Err(Error::StreamClosed) => false,
 		}
 	}
 }

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -31,7 +31,7 @@ use futures::{
 	ready,
 };
 #[cfg(feature = "std")]
-use log::trace;
+use tracing::trace;
 
 use parking_lot::Mutex;
 

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -642,8 +642,29 @@ where
 	/// Otherwise, we will simply handle the commit and issue a finalization command
 	/// to the environment.
 	fn process_incoming(&mut self, cx: &mut Context) -> Result<(), E::Error> {
-		while let Poll::Ready(Some(item)) = Stream::poll_next(Pin::new(&mut self.global_in), cx) {
-			match item? {
+		// Drain all incoming messages from the global input stream.
+		loop {
+			let item = match self.global_in.poll_next_unpin(cx) {
+				Poll::Ready(Some(item)) => match item {
+					Ok(item) => item,
+					Err(e) => return Err(e),
+				},
+				Poll::Ready(None) => {
+					tracing::error!(
+						target: LOG_TARGET,
+						"Global input stream has been closed, no more messages will be processed."
+					);
+
+					// the stream is closed, we can't process any more messages.
+					return Err(crate::Error::StreamClosed.into());
+				},
+				Poll::Pending => {
+					// no messages available, we can return now.
+					return Ok(())
+				},
+			};
+
+			match item {
 				CommunicationIn::Commit(round_number, commit, mut process_commit_outcome) => {
 					trace!(
 						target: LOG_TARGET,
@@ -764,8 +785,6 @@ where
 				},
 			}
 		}
-
-		Ok(())
 	}
 
 	// process the logic of the best round.

--- a/src/voter/past_rounds.rs
+++ b/src/voter/past_rounds.rs
@@ -30,7 +30,7 @@ use futures::{
 	task,
 };
 #[cfg(feature = "std")]
-use log::{debug, trace};
+use tracing::{debug, trace};
 
 use std::{
 	cmp,

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -18,7 +18,7 @@
 use futures::ready;
 use futures::{channel::mpsc::UnboundedSender, prelude::*};
 #[cfg(feature = "std")]
-use log::{debug, trace, warn};
+use tracing::{debug, trace, warn};
 
 use std::{
 	pin::Pin,
@@ -236,7 +236,7 @@ where
 				"Round {} completable but estimate not finalized.",
 				self.round_number()
 			);
-			self.log_participation(log::Level::Trace);
+			self.log_participation(tracing::Level::TRACE);
 			return Poll::Pending
 		}
 
@@ -248,7 +248,7 @@ where
 			self.state
 		);
 
-		self.log_participation(log::Level::Debug);
+		self.log_participation(tracing::Level::DEBUG);
 
 		// both exit conditions verified, we can complete this round
 		Poll::Ready(Ok(()))
@@ -411,7 +411,7 @@ where
 		Ok(())
 	}
 
-	fn log_participation(&self, log_level: log::Level) {
+	fn log_participation(&self, log_level: tracing::Level) {
 		let total_weight = self.voters().total_weight();
 		let threshold = self.voters().threshold();
 		let n_voters = self.voters().len();
@@ -420,8 +420,20 @@ where
 		let (prevote_weight, n_prevotes) = self.votes.prevote_participation();
 		let (precommit_weight, n_precommits) = self.votes.precommit_participation();
 
-		log::log!(
-			target: LOG_TARGET,
+		// Helper macro to avoid repetition and overcome log target not being const.
+		macro_rules! log_event {
+			($level:expr, $($args:tt)+) => {
+				match $level {
+					tracing::Level::ERROR => tracing::error!(target: LOG_TARGET, $($args)+),
+					tracing::Level::WARN => tracing::warn!(target: LOG_TARGET, $($args)+),
+					tracing::Level::INFO => tracing::info!(target: LOG_TARGET, $($args)+),
+					tracing::Level::DEBUG => tracing::debug!(target: LOG_TARGET, $($args)+),
+					tracing::Level::TRACE => tracing::trace!(target: LOG_TARGET, $($args)+),
+				}
+			};
+		}
+
+		log_event!(
 			log_level,
 			"Round {}: prevotes: {}/{}/{} weight, {}/{} actual",
 			number,
@@ -432,8 +444,7 @@ where
 			n_voters
 		);
 
-		log::log!(
-			target: LOG_TARGET,
+		log_event!(
 			log_level,
 			"Round {}: precommits: {}/{}/{} weight, {}/{} actual",
 			number,

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -727,10 +727,11 @@ where
 								last_round_estimate.0
 							}
 						},
-						Err(crate::Error::NotDescendent) => {
+						Err(err) => {
 							// This is only possible in case of massive equivocation
 							warn!(
 								target: LOG_TARGET,
+								?err,
 								"Possible case of massive equivocation: \
 								last round prevote GHOST: {:?} is not a descendant of last round estimate: {:?}",
 								last_prevote_g,

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -727,11 +727,10 @@ where
 								last_round_estimate.0
 							}
 						},
-						Err(err) => {
+						Err(crate::Error::NotDescendent) => {
 							// This is only possible in case of massive equivocation
 							warn!(
 								target: LOG_TARGET,
-								?err,
 								"Possible case of massive equivocation: \
 								last round prevote GHOST: {:?} is not a descendant of last round estimate: {:?}",
 								last_prevote_g,
@@ -740,6 +739,7 @@ where
 
 							last_round_estimate.0
 						},
+						Err(crate::Error::StreamClosed) => last_round_estimate.0,
 					}
 				}
 			},


### PR DESCRIPTION
This PR ensures that the voter logic stops when the `global_in` stream is terminated.

While at it, have replaced the `log` dependency with `tracing`
