### PR TITLE
voter: Ensure prevoting future is polled directly after advancing the state

### DIFF
--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -538,13 +538,6 @@ where
 					);
 
 					let (base, best_chain) = this.construct_prevote(last_round_state);
-
-					// since we haven't polled the future above yet we need to
-					// manually schedule the current task to be awoken so the
-					// `best_chain` future is then polled below after we switch the
-					// state to `Prevoting`.
-					cx.waker().wake_by_ref();
-
 					this.state = Some(State::Prevoting(precommit_timer, (base, best_chain)));
 					return Ok(true)
 				} else {

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -517,8 +517,7 @@ where
 		cx: &mut Context,
 		last_round_state: &RoundState<H, N>,
 	) -> Result<(), E::Error> {
-		let state = self.state.take();
-
+		// Returns true if the state advances to `Prevoting`.
 		let start_prevoting = |this: &mut Self,
 		                       mut prevote_timer: E::Timer,
 		                       precommit_timer: E::Timer,
@@ -547,6 +546,7 @@ where
 					cx.waker().wake_by_ref();
 
 					this.state = Some(State::Prevoting(precommit_timer, (base, best_chain)));
+					return Ok(true)
 				} else {
 					this.state = Some(State::Prevoted(precommit_timer));
 				}
@@ -556,7 +556,7 @@ where
 				this.state = Some(State::Start(prevote_timer, precommit_timer));
 			}
 
-			Ok(())
+			Ok(false)
 		};
 
 		let finish_prevoting = |this: &mut Self,
@@ -597,19 +597,37 @@ where
 			Ok(())
 		};
 
-		match state {
-			Some(State::Start(prevote_timer, precommit_timer)) => {
-				start_prevoting(self, prevote_timer, precommit_timer, false, cx)?;
-			},
-			Some(State::Proposed(prevote_timer, precommit_timer)) => {
-				start_prevoting(self, prevote_timer, precommit_timer, true, cx)?;
-			},
+		// If we are starting the prevoting phase (ie we have moved from to `State::Prevoting`),
+		// the context waker needs to be saved by the `best_chain` future.
+		// Instead of waking up the whole task, perform on final step to ensure the waker is saved.
+		let state = self.state.take();
+		let should_poll_prevoting = match state {
+			Some(State::Start(prevote_timer, precommit_timer)) =>
+				start_prevoting(self, prevote_timer, precommit_timer, false, cx)?,
+			Some(State::Proposed(prevote_timer, precommit_timer)) =>
+				start_prevoting(self, prevote_timer, precommit_timer, true, cx)?,
 			Some(State::Prevoting(precommit_timer, (base, best_chain))) => {
 				finish_prevoting(self, precommit_timer, base, best_chain, cx)?;
+				false
 			},
 			x => {
 				self.state = x;
+				false
 			},
+		};
+
+		if should_poll_prevoting {
+			// we have switched to `State::Prevoting`, so we need to poll the `best_chain` future to sale the waker.
+			let state = self.state.take();
+			if let Some(State::Prevoting(precommit_timer, (base, best_chain))) = state {
+				finish_prevoting(self, precommit_timer, base, best_chain, cx)?;
+			} else {
+				panic!(
+					"Expected state to be `State::Prevoting` after polling `start_prevoting`, \
+					but got: {:?}",
+					state
+				);
+			}
 		}
 
 		Ok(())

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -590,7 +590,7 @@ where
 			Ok(())
 		};
 
-		// If we are starting the prevoting phase (ie we have moved from to `State::Prevoting`),
+		// If we are starting the prevoting phase (ie we have moved to `State::Prevoting`),
 		// the context waker needs to be saved by the `best_chain` future.
 		// Instead of waking up the whole task, perform on final step to ensure the waker is saved.
 		let state = self.state.take();


### PR DESCRIPTION
This PR avoids a call to the `cx.waker().wake_by_ref()` by polling the appropriate `finish_prevoting` future.

Previously, we relied on the context waker to wake up the whole async task if the state advanced to `Prevoting` via the `start_prevoting` fn. I believe the intended behavior was to save the waker on the subsequent call by polling the `best_chain` future.

Instead, we poll the `best_chain` future directly without waking up the task. 

cc @paritytech/networking @alexggh https://github.com/paritytech/polkadot-sdk/issues/8543


## Next Steps
- [ ] This needs a bit of testing to ensure that `wake_by_ref` did not have unexpected side-effects which unblocked other futures from continuing to operate, which may explain the finality stall in the linked issue
