### PR TITLE
voter: Use `_unpin` methods for polling

### DIFF
--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -376,9 +376,9 @@ impl<S: Sink<I> + Unpin, I> Buffered<S, I> {
 		let polled = self.schedule_all(cx)?;
 
 		match polled {
-			Poll::Ready(()) => Sink::poll_flush(Pin::new(&mut self.inner), cx),
+			Poll::Ready(()) => self.inner.poll_flush_unpin(cx),
 			Poll::Pending => {
-				ready!(Sink::poll_flush(Pin::new(&mut self.inner), cx))?;
+				ready!(self.inner.poll_flush_unpin(cx))?;
 				Poll::Pending
 			},
 		}
@@ -386,13 +386,13 @@ impl<S: Sink<I> + Unpin, I> Buffered<S, I> {
 
 	fn schedule_all(&mut self, cx: &mut Context) -> Poll<Result<(), S::Error>> {
 		while !self.buffer.is_empty() {
-			ready!(Sink::poll_ready(Pin::new(&mut self.inner), cx))?;
+			ready!(self.inner.poll_ready_unpin(cx))?;
 
 			let item = self
 				.buffer
 				.pop_front()
 				.expect("we checked self.buffer.is_empty() just above; qed");
-			Sink::start_send(Pin::new(&mut self.inner), item)?;
+			self.inner.start_send_unpin(item)?;
 		}
 
 		Poll::Ready(Ok(()))

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -602,17 +602,13 @@ where
 			let mut inner = self.inner.lock();
 
 			// Do work on all background rounds, broadcasting any commits generated.
-			while let Poll::Ready(Some(item)) =
-				Stream::poll_next(Pin::new(&mut inner.past_rounds), cx)
-			{
+			while let Poll::Ready(Some(item)) = inner.past_rounds.poll_next_unpin(cx) {
 				let (number, commit) = item?;
 				self.global_out.push(CommunicationOut::Commit(number, commit));
 			}
 		}
 
-		while let Poll::Ready(res) =
-			Stream::poll_next(Pin::new(&mut self.finalized_notifications), cx)
-		{
+		while let Poll::Ready(res) = self.finalized_notifications.poll_next_unpin(cx) {
 			let inner = self.inner.clone();
 			let mut inner = inner.lock();
 
@@ -642,7 +638,7 @@ where
 	/// Otherwise, we will simply handle the commit and issue a finalization command
 	/// to the environment.
 	fn process_incoming(&mut self, cx: &mut Context) -> Result<(), E::Error> {
-		while let Poll::Ready(Some(item)) = Stream::poll_next(Pin::new(&mut self.global_in), cx) {
+		while let Poll::Ready(Some(item)) = self.global_in.poll_next_unpin(cx) {
 			match item? {
 				CommunicationIn::Commit(round_number, commit, mut process_commit_outcome) => {
 					trace!(

--- a/src/voter/past_rounds.rs
+++ b/src/voter/past_rounds.rs
@@ -323,7 +323,7 @@ where
 
 	fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
 		loop {
-			match Stream::poll_next(Pin::new(&mut self.past_rounds), cx) {
+			match self.past_rounds.poll_next_unpin(cx) {
 				Poll::Ready(Some((Ok(BackgroundRoundChange::Concluded(number)), round))) => {
 					let round = &round.inner;
 					round.env().concluded(

--- a/src/voter/past_rounds.rs
+++ b/src/voter/past_rounds.rs
@@ -190,9 +190,7 @@ where
 		cx: &mut Context,
 		voting_round: &mut VotingRound<H, N, E>,
 	) -> Poll<Result<Option<Commit<H, N, E::Signature, E::Id>>, E::Error>> {
-		while let Poll::Ready(Some(commit)) =
-			Stream::poll_next(Pin::new(&mut self.import_commits), cx)
-		{
+		while let Poll::Ready(Some(commit)) = self.import_commits.poll_next_unpin(cx) {
 			if !self.import_commit(voting_round, commit)? {
 				trace!(target: LOG_TARGET, "Ignoring invalid commit");
 			}

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -21,7 +21,6 @@ use futures::{channel::mpsc::UnboundedSender, prelude::*};
 use log::{debug, trace, warn};
 
 use std::{
-	pin::Pin,
 	sync::Arc,
 	task::{Context, Poll},
 };
@@ -446,8 +445,7 @@ where
 	}
 
 	fn process_incoming(&mut self, cx: &mut Context) -> Result<(), E::Error> {
-		while let Poll::Ready(Some(incoming)) = Stream::poll_next(Pin::new(&mut self.incoming), cx)
-		{
+		while let Poll::Ready(Some(incoming)) = self.incoming.poll_next_unpin(cx) {
 			trace!(target: LOG_TARGET, "Round {}: Got incoming message", self.round_number());
 			self.handle_vote(incoming?)?;
 		}


### PR DESCRIPTION
This tiny PR uses the `_unpin` equivalent of `Sink::poll_*(Pin::new(..))`.