### PR TITLE
voter: Save the context waker of precommited voting rounds

### DIFF
--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -775,20 +775,31 @@ where
 		{
 			let mut inner = self.inner.lock();
 
-			let should_start_next = {
-				let completable = match inner.best_round.poll(cx)? {
-					Poll::Ready(()) => true,
-					Poll::Pending => false,
-				};
-
-				// start when we've cast all votes.
-				let precommitted =
-					matches!(inner.best_round.state(), Some(&VotingRoundState::Precommitted));
-
-				completable && precommitted
+			// Best round must be completable before we can start a new one.
+			match inner.best_round.poll(cx)? {
+				Poll::Ready(()) => {},
+				Poll::Pending => return Poll::Pending,
 			};
 
-			if !should_start_next {
+			// The state of the best round must advance to the point where we can
+			// start a new round.
+			// We can effectively start a new round when:
+			// - the best round future completed
+			// - the best round state is precommitted, which means we have cast all votes
+			let precommitted =
+				matches!(inner.best_round.state(), Some(&VotingRoundState::Precommitted));
+			if !precommitted {
+				trace!(
+					target: LOG_TARGET,
+					"Best round at {} is not precommitted. Waiting for precommit in state {:?}",
+					inner.best_round.round_number(),
+					inner.best_round.state(),
+				);
+
+				// This ensures we are not causing delays in the voting process. Previously,
+				// we relied on polling the future again which would save the waker via `process_incoming`.
+				inner.best_round.set_waker(cx.waker().clone());
+
 				return Poll::Pending
 			}
 

--- a/src/voter/mod.rs
+++ b/src/voter/mod.rs
@@ -809,38 +809,32 @@ where
 				inner.best_round.round_number(),
 				inner.best_round.round_number() + 1,
 			);
-		}
 
-		self.completed_best_round()?;
+			// Complete the best round and start a new one.
+			self.env.completed(
+				inner.best_round.round_number(),
+				inner.best_round.round_state(),
+				inner.best_round.dag_base(),
+				inner.best_round.historical_votes(),
+			)?;
+
+			let old_round_number = inner.best_round.round_number();
+
+			let next_round = VotingRound::new(
+				old_round_number + 1,
+				self.voters.clone(),
+				self.last_finalized_in_rounds.clone(),
+				Some(inner.best_round.bridge_state()),
+				inner.best_round.finalized_sender(),
+				self.env.clone(),
+			);
+
+			let old_round = ::std::mem::replace(&mut inner.best_round, next_round);
+			inner.past_rounds.push(&*self.env, old_round);
+		}
 
 		// round has been updated. so we need to re-poll.
 		self.poll_unpin(cx)
-	}
-
-	fn completed_best_round(&mut self) -> Result<(), E::Error> {
-		let mut inner = self.inner.lock();
-
-		self.env.completed(
-			inner.best_round.round_number(),
-			inner.best_round.round_state(),
-			inner.best_round.dag_base(),
-			inner.best_round.historical_votes(),
-		)?;
-
-		let old_round_number = inner.best_round.round_number();
-
-		let next_round = VotingRound::new(
-			old_round_number + 1,
-			self.voters.clone(),
-			self.last_finalized_in_rounds.clone(),
-			Some(inner.best_round.bridge_state()),
-			inner.best_round.finalized_sender(),
-			self.env.clone(),
-		);
-
-		let old_round = ::std::mem::replace(&mut inner.best_round, next_round);
-		inner.past_rounds.push(&*self.env, old_round);
-		Ok(())
 	}
 
 	fn set_last_finalized_number(&mut self, finalized_number: N) -> bool {

--- a/src/voter/voting_round.rs
+++ b/src/voter/voting_round.rs
@@ -74,6 +74,11 @@ where
 	primary_block: Option<(H, N)>,                     // a block posted by primary as a hint.
 	finalized_sender: UnboundedSender<FinalizedNotification<H, N, E>>,
 	best_finalized: Option<Commit<H, N, E::Signature, E::Id>>,
+
+	/// Waker to notify that we have switched to the precommited state
+	/// if we have returned `Poll::Pending` in the previous poll of
+	/// the `Voter::process_best_round`.
+	waker: Option<std::task::Waker>,
 }
 
 /// Whether we should vote in the current round (i.e. push votes to the sink.)
@@ -138,6 +143,7 @@ where
 			env,
 			last_round_state,
 			finalized_sender,
+			waker: None,
 		}
 	}
 
@@ -163,6 +169,7 @@ where
 			last_round_state,
 			finalized_sender,
 			best_finalized: None,
+			waker: None,
 		}
 	}
 
@@ -653,6 +660,11 @@ where
 						self.votes.set_precommitted_index();
 						self.outgoing.push(Message::Precommit(precommit));
 					}
+
+					if let Some(ref waker) = self.waker {
+						waker.wake_by_ref();
+					}
+
 					self.state = Some(State::Precommitted);
 				} else {
 					self.state = Some(State::Prevoted(precommit_timer));
@@ -666,7 +678,13 @@ where
 		Ok(())
 	}
 
-	// construct a prevote message based on local state.
+	/// Sets the internal waker to be used when we return `Poll::Pending` in the
+	/// `Voter::process_best_round` method.
+	pub(super) fn set_waker(&mut self, waker: std::task::Waker) {
+		self.waker = Some(waker);
+	}
+
+	/// Construct a prevote message based on local state.
 	fn construct_prevote(&self, last_round_state: &RoundState<H, N>) -> (H, E::BestChain) {
 		let last_round_estimate = last_round_state
 			.estimate


### PR DESCRIPTION
A best round is completed when the following conditions are met: 
- The best round future is completed (ie `inner.best_round.poll(cx)` returns `Poll::Ready(())`)
- The state of the best round state advances to `Precommited` (from `Prevoting`)

When one of the previous conditions is not met, the `process_best_round` function returns `Poll::Pending` without storing the waker context.

The grandpa code relies on the first context wakeup of either:
- incoming events via the global input stream (ie `process_incoming`)
- pruning background rounds (either a past round generated a commit, or we receive a finalization notification)
- global output wakes the waker
https://github.com/paritytech/finality-grandpa/blob/321973e4a138f1e00a4dda5bbdd838871d4e45a7/src/voter/mod.rs#L854-L860


This PR ensures we save the waker and wake it up properly on state advances (instead of relying on the above components and possibly causing a delay in starting the next round). 

### Notes

We are also seeing a high number of grandpa debug los:
```
2025-06-06 20:10:51.909 DEBUG tokio-runtime-worker grandpa: Completed round 50, state = State { prevote_ghost: Some((0xa82f134d09119028e9b5c8f1846a0440d66f284292cd57ebfba0bfaf31e44a54, 4469)), finalized: Some((0xa82f134d09119028e9b5c8f1846a0440d66f284292cd57ebfba0bfaf31e44a54, 4469)), estimate: Some((0xa82f134d09119028e9b5c8f1846a0440d66f284292cd57ebfba0bfaf31e44a54, 4469)), completable: true }, step = Some(Prevoting)  
	
2025-06-06 20:10:51.909 DEBUG tokio-runtime-worker grandpa: Completed round 50, state = State { prevote_ghost: Some((0xa82f134d09119028e9b5c8f1846a0440d66f284292cd57ebfba0bfaf31e44a54, 4469)), finalized: Some((0xa82f134d09119028e9b5c8f1846a0440d66f284292cd57ebfba0bfaf31e44a54, 4469)), estimate: Some((0xa82f134d09119028e9b5c8f1846a0440d66f284292cd57ebfba0bfaf31e44a54, 4469)), completable: true }, step = Some(Prevoting)    

2025-06-06 20:10:51.914 DEBUG tokio-runtime-worker grandpa: Completed round 50, state = State { prevote_ghost: Some((0xa82f134d09119028e9b5c8f1846a0440d66f284292cd57ebfba0bfaf31e44a54, 4469)), finalized: Some((0xa82f134d09119028e9b5c8f1846a0440d66f284292cd57ebfba0bfaf31e44a54, 4469)), estimate: Some((0xa82f134d09119028e9b5c8f1846a0440d66f284292cd57ebfba0bfaf31e44a54, 4469)), completable: true }, step = Some(Prevoting)    
```

The previous logs are repeated ~3.4k times during one second during a finality stall, suggesting that some other component (mentioned above) was able to make progress, but not yet the best voting round.

I would leave this PR open for a while, in case we choose to revisit it at a later time and perform in-depth testing. (May we ever want to refactor the code to align with https://github.com/paritytech/finality-grandpa/issues/124 this might come in handy)
